### PR TITLE
Match __getTrackByte, update libultra fn name

### DIFF
--- a/conker/conker.us.yaml
+++ b/conker/conker.us.yaml
@@ -64,7 +64,7 @@ segments:
     - [0x13320, c, libultra/audio/n_csplayer]
     - [0x15550, c, libultra/audio/init_15550]
     - [0x17870, c, libultra/audio/init_17870]
-    - [0x17A80, c, libultra/audio/init_17A80]
+    - [0x17A80, c, libultra/audio/n_cspgetstate]
     - [0x17AA0, c, libultra/audio/code_17AA0]
     - [0x17AF0, c, libultra/audio/init_17AF0]
     - [0x17C00, c, libultra/audio/init_17C00]

--- a/conker/src/init_8180.c
+++ b/conker/src/init_8180.c
@@ -32,13 +32,13 @@ void func_10018D50(N_ALCSPlayer *seqp);
 #pragma GLOBAL_ASM("asm/nonmatchings/init_8180/func_10008180.s")
 
 void func_100084D8(u8 idx) {
-    if ((func_10017A80(D_8003C900[idx]) == 0) || (func_10017A80(D_8003C900[idx]) == 3)) {
+    if ((n_alCSPGetState(D_8003C900[idx]) == 0) || (n_alCSPGetState(D_8003C900[idx]) == 3)) {
         func_10017AA0(D_8003C900[idx]);
     }
 }
 
 s32 func_1000853C(u8 idx) {
-    return func_10017A80(D_8003C900[idx]);
+    return n_alCSPGetState(D_8003C900[idx]);
 }
 
 void func_10008570(u8 idx, s32 arg1) { // arg1 is OSMesgQueue ?
@@ -185,13 +185,13 @@ void func_10008C04(u8 idx, u8 arg1, s32 arg2) {
 //
 //     i = 0;
 //     func_10018C60(&D_8003C900[idx]);
-//     while ((func_10017A80(&D_8003C900[idx]) != 0) && (i < 2000000)) {
+//     while ((n_alCSPGetState(&D_8003C900[idx]) != 0) && (i < 2000000)) {
 //         i++;
 //     };
 //
 //     if (i >= 2000000) {
 //         func_10018C60(&D_8003C900[idx]);
-//         while ((func_10017A80(&D_8003C900[idx]) != 0) && (i < 4000000)) {
+//         while ((n_alCSPGetState(&D_8003C900[idx]) != 0) && (i < 4000000)) {
 //             i++;
 //         }
 //     }

--- a/conker/src/libultra/audio/init_17A80.c
+++ b/conker/src/libultra/audio/init_17A80.c
@@ -1,6 +1,0 @@
-#include <n_libaudio.h>
-
-// get_csp_state
-s32 func_10017A80(N_ALCSPlayer *seqp) {
-    return seqp->state;
-}

--- a/conker/src/libultra/audio/n_cspgetstate.c
+++ b/conker/src/libultra/audio/n_cspgetstate.c
@@ -1,0 +1,5 @@
+#include <n_libaudio.h>
+
+s32 n_alCSPGetState(N_ALCSPlayer *seqp) {
+    return seqp->state;
+}

--- a/conker/src/libultra/audio/n_synthesizer.c
+++ b/conker/src/libultra/audio/n_synthesizer.c
@@ -185,7 +185,7 @@ extern f32 D_8002C750;
 //     return sp38;
 // }
 
-ALParam *__n_allocParam() {
+ALParam *__n_allocParam(void) {
     ALParam *update = 0;
 
     if (n_syn->paramList) {
@@ -194,7 +194,7 @@ ALParam *__n_allocParam() {
         update->next = 0;
     }
     return update;
-  }
+}
 
 
 void _n_freeParam(ALParam *param)

--- a/conker/symbol_addrs.us.txt
+++ b/conker/symbol_addrs.us.txt
@@ -25,6 +25,7 @@ __n_CSPRepostEvent              = 0x10015310;
 __n_setUsptFromTempo            = 0x10015464;
 __n_CSPPostNextSeqEvent         = 0x100154AC;
 _n_handleEvent                  = 0x10015944;
+n_alCSPGetState                 = 0x10017A80;
 n_alCSPGetTempo                 = 0x10017EC0;
 n_alCSeqNew                     = 0x10017F80;
 n_alCSeqNextEvent               = 0x10018100;


### PR DESCRIPTION
- Matched `__getTrackByte()` by taking it straight from the dk64 decomp.

- Identified and labelled `n_alCSPGetState` using the [Yoshi's Story decomp](https://github.com/decompals/yoshis-story/blob/f3f3f853233e1008a43bd6050627f02c56cebafe/lib/ultralib/src/audio/cspgetstate.c#L25).

  - I have seen others be not very happy about people naming symbols early on, but this is a  very common libultra fn, so it seems fine to do now.
  
- Fix `__readVarLen()` parameter type