### PR TITLE
Fix GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,14 +9,14 @@ on:
 jobs:
   build:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout this repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Checkout baserom
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: mkst/conker-private
         token: ${{ secrets.PRIVATE_REPO_ACCESS }}
@@ -25,30 +25,30 @@ jobs:
       run: echo ${{ secrets.CONKER_BASEROM_US }} | openssl enc -d -aes-256-cbc -pass stdin -pbkdf2 -in baserom/baserom.us.z64.aes -out baserom.us.z64
 
     - name: Perform make extract (rom)
-      uses: docker://docker.io/markstreet/conker:latest
+      uses: docker://ghcr.io/mkst/conker:latest
       with:
         args: make extract
 
     - name: Perform make extract (code)
-      uses: docker://docker.io/markstreet/conker:latest
+      uses: docker://ghcr.io/mkst/conker:latest
       with:
         args: sh -c "cd conker && make extract"
     - name: Perform make (code)
-      uses: docker://docker.io/markstreet/conker:latest
+      uses: docker://ghcr.io/mkst/conker:latest
       with:
         args: sh -c "cd conker && make --jobs"
     - name: Perform make replace
-      uses: docker://docker.io/markstreet/conker:latest
+      uses: docker://ghcr.io/mkst/conker:latest
       with:
         args: sh -c "cd conker && make replace"
 
     - name: Perform make
-      uses: docker://docker.io/markstreet/conker:latest
+      uses: docker://ghcr.io/mkst/conker:latest
       with:
         args: make --jobs
 
     - name: Create progress.csv
-      uses: docker://docker.io/markstreet/conker:latest
+      uses: docker://ghcr.io/mkst/conker:latest
       with:
         args: sh -c "cd conker && make progress"
 
@@ -63,12 +63,13 @@ jobs:
 
     - name: Push progress.csv to conker-website repo
       if: ${{ github.event_name == 'push' }}
-      uses: dmnemec/copy_file_to_another_repo_action@v1.0.4
+      uses: dmnemec/copy_file_to_another_repo_action@bbebd3da22e4a37d04dca5f782edd5201cb97083
       env:
         API_TOKEN_GITHUB: ${{ secrets.WEBSITE_REPO_ACCESS }}
       with:
         source_file: "${{ steps.vars.outputs.progress_filename }}"
         destination_repo: 'mkst/conker-website'
         destination_folder: 'progress/data'
+        destination_branch: 'master'
         user_email: 'streetster@gmail.com'
         user_name: 'mkst'

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -7,16 +7,16 @@ on:
 jobs:
   build_pr:
     if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout this repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: recursive
         ref: ${{ github.event.pull_request.head.ref }}
         repository: ${{ github.event.pull_request.head.repo.full_name }}
     - name: Checkout baserom
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: mkst/conker-private
         token: ${{ secrets.PRIVATE_REPO_ACCESS }}
@@ -24,25 +24,25 @@ jobs:
     - name: Decrypt baserom
       run: echo ${{ secrets.CONKER_BASEROM_US }} | openssl enc -d -aes-256-cbc -pass stdin -pbkdf2 -in baserom/baserom.us.z64.aes -out baserom.us.z64
 
-    - name: Perform make extract
-      uses: docker://docker.io/markstreet/conker:latest
+    - name: Perform make extract (rom)
+      uses: docker://ghcr.io/mkst/conker:latest
       with:
         args: make extract
 
     - name: Perform make extract (code)
-      uses: docker://docker.io/markstreet/conker:latest
+      uses: docker://ghcr.io/mkst/conker:latest
       with:
         args: sh -c "cd conker && make extract"
     - name: Perform make (code)
-      uses: docker://docker.io/markstreet/conker:latest
+      uses: docker://ghcr.io/mkst/conker:latest
       with:
         args: sh -c "cd conker && make --jobs"
     - name: Perform make replace
-      uses: docker://docker.io/markstreet/conker:latest
+      uses: docker://ghcr.io/mkst/conker:latest
       with:
         args: sh -c "cd conker && make replace"
 
     - name: Perform make
-      uses: docker://docker.io/markstreet/conker:latest
+      uses: docker://ghcr.io/mkst/conker:latest
       with:
         args: make --jobs

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -18,22 +18,12 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push to Docker Hub
-        uses: docker/build-push-action@v6
-        with:
-          push: true
-          tags: markstreet/conker:latest
       - name: Build and push to Github registry
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -2,6 +2,12 @@ name: Create and push Docker build image
 on:
   push:
     branches: [ master ]
+    paths:
+      - Dockerfile
+      - packages.txt
+      - requirements.txt
+      - .bash_aliases
+      - .github/workflows/docker.yaml
 jobs:
   push_to_dockerhub:
     name: Publish Docker build image to Github Registry

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -4,10 +4,11 @@ on:
     branches: [ master ]
 jobs:
   push_to_dockerhub:
-    name: Publish Docker build image to Docker Hub + Github Registry
+    name: Publish Docker build image to Github Registry
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -16,12 +17,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Log in to GitHub Docker Registry
+      - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push to Docker Hub
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -10,25 +10,25 @@ jobs:
       contents: read
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Log in to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Log in to GitHub Docker Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GHCR_PAT }}
       - name: Build and push to Docker Hub
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           push: true
           tags: markstreet/conker:latest
       - name: Build and push to Github registry
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           push: true
           tags: ghcr.io/${{ github.repository_owner }}/conker:latest

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ attrs
 capstone
 colorama
 cxxfilt
+git
 pycparser
 pylibyaml
 pynacl


### PR DESCRIPTION
The actions on this repo are not running. Ubuntu 20.04 runner is fully unsupported, so no workflow will run on it. See https://github.com/actions/runner-images/issues/11101

Changes:

- Set Ubuntu version to float to latest
- Fix docker.io --> ghcr.io
- Bump actions versions
- Explicitly set target branch for copy_file_to_another_repo_action action
  - The default branch option for this action was changed from master to main at some point