### PR TITLE
Update Dockerfile to Ubuntu 24.04

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
+{
+	"name": "Existing Dockerfile",
+	"build": {
+		// Sets the run context to one level up instead of the .devcontainer folder.
+		"context": "..",
+		// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+		"dockerfile": "../Dockerfile"
+	}
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "cat /etc/os-release",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "devcontainer"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 as build
+FROM ubuntu:24.04 AS build
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -6,8 +6,11 @@ COPY /packages.txt /
 
 RUN apt-get update && apt-get install -y $(cat /packages.txt)
 
-COPY requirements.txt /
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
+COPY requirements.txt /
 RUN python3 -m pip install -r /requirements.txt --no-cache-dir
 
 COPY .bash_aliases /root/.bash_aliases

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Clean and build the ROM.
+
+set -e
+
+rm -f .baserom.us.ok
+rm -f conker.ld
+rm -f conker/conker.ld
+make really-clean
+make -C conker really-clean
+
+make check
+make extract
+make -C conker extract
+make -C conker -j
+make -C conker replace
+make -j

--- a/packages.txt
+++ b/packages.txt
@@ -3,7 +3,9 @@ build-essential
 git
 less
 libglib2.0
+python-is-python3
 python3
 python3-pip
+python3-venv
 unzip
 wget


### PR DESCRIPTION
# Summary

Update Dockerfile to Ubuntu 24.04, because the current container runs Python 3.8. The new n64splat versions only support Python >=3.9, so we need this.
  - We have to install pip packages in a venv because starting with Ubuntu 24.04 it errors by default when attempting to install globally.
  - For reference, the [dk64 Dockerfile](https://gitlab.com/dk64_decomp/dk64/-/blob/main/Dockerfile?ref_type=heads) I made. It's very similar.

## Other changes

- Add devcontainer config (very helpful for development using VSCode)

- Add a utility script for devs, `build.sh`, to clean and build everything from scratch
  - This repo could use some tools updates regards to make dependencies. Too many commands to run manually, and there is an implicit command dependency order that should probably be stipulated in the Makefile. And if you modify stuff like the `.txt` files, the Makefile doesn't clean affected files even though it should. But for now, this script is a big help.
  - This could also probably be added as a command in the `Makefile`, but I left it separate for now.

## Testing

I tested locally by building the Docker container and running build.sh and everything works as expected.

If misc scripts in `tools/` are broken by the Python upgrade, we will fix them as we go.