### PR TITLE
Update mips_to_c submodule

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -1,6 +1,6 @@
 # bash aliases for ease of use, copy/append to ~/.bash_aliases
 
-alias m2c='python3 tools/mips_to_c/mips_to_c.py '
+alias m2c='python3 tools/mips_to_c/m2c.py '
 alias di='python3 tools/decomp-permuter/import.py '
 alias dp='python3 tools/decomp-permuter/permuter.py --best-only -j3 '
 alias ad='python3 tools/asm-differ/diff.py -mwo3 '


### PR DESCRIPTION
# Summary

Current m2c submodule version doesn't work with modern Python, so update it to the newest.

## Testing

### Before

```sh
root@f658660297e3:/workspaces/conker# m2c
...
  label += f"switch ({switch_control.control_expr.format(fmt)})\l"
/workspaces/conker/tools/mips_to_c/src/flow_graph.py:1457: SyntaxWarning: invalid escape sequence '\l'
  label += "// exit\l"
Traceback (most recent call last):
  File "/workspaces/conker/tools/mips_to_c/mips_to_c.py", line 2, in <module>
    from src.main import main
  File "/workspaces/conker/tools/mips_to_c/src/main.py", line 10, in <module>
    from .flow_graph import visualize_flowgraph
  File "/workspaces/conker/tools/mips_to_c/src/flow_graph.py", line 19, in <module>
    from .options import Formatter
  File "/workspaces/conker/tools/mips_to_c/src/options.py", line 55, in <module>
    @dataclass
     ^^^^^^^^^
  File "/usr/lib/python3.12/dataclasses.py", line 1268, in dataclass
    return wrap(cls)
           ^^^^^^^^^
  File "/usr/lib/python3.12/dataclasses.py", line 1258, in wrap
    return _process_class(cls, init, repr, eq, order, unsafe_hash,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/dataclasses.py", line 994, in _process_class
    cls_fields.append(_get_field(cls, name, type, kw_only))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/dataclasses.py", line 852, in _get_field
    raise ValueError(f'mutable default {type(f.default)} for field '
ValueError: mutable default <class 'src.options.CodingStyle'> for field coding_style is not allowed: use default_factory
```

### After

```sh
root@f658660297e3:/workspaces/conker# m2c "/workspaces/conker/conker/asm/nonmatchings/game/done/game_122650/func_150F51A0.s"
extern s8 D_80088B40;

void func_150F51A0(s32 arg0, ? arg1) {
    D_80088B40 = 1;
}
```