### PR TITLE
Decompile small game stubs

### DIFF
--- a/conker/include/macro.inc
+++ b/conker/include/macro.inc
@@ -15,7 +15,13 @@
     \label:
 .endm
 
+.macro enddlabel label
+.endm
+
 .macro jlabel label
     .global \label
     \label:
+.endm
+
+.macro nonmatching label, size
 .endm

--- a/conker/src/game_161520.c
+++ b/conker/src/game_161520.c
@@ -122,7 +122,12 @@ void func_1513477C(struct102 *arg0) {
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_161520/func_151355B8.s")
 
-#pragma GLOBAL_ASM("asm/nonmatchings/game_161520/func_15135658.s")
+s32 func_15135658(void *arg0) {
+    s32 ret = 1;
+
+    *(f32 *)((u8 *)arg0 + 0x74) = 1.0f;
+    return ret;
+}
 
 f32 func_15135670(s32 arg0) {
     // "power", "../Effects/Blood/blood.c"

--- a/conker/src/game_161520.c
+++ b/conker/src/game_161520.c
@@ -152,7 +152,17 @@ f32 func_15135670(s32 arg0) {
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_161520/func_15136918.s")
 
-#pragma GLOBAL_ASM("asm/nonmatchings/game_161520/func_15136A1C.s")
+s32 func_15136A1C(struct102 *arg0) {
+    s16 idx = arg0->unk1C;
+
+    if (idx < 32) {
+        s32 value = idx * 8;
+        if (value < arg0->unk28) {
+            arg0->unk28 = value;
+        }
+    }
+    return 1;
+}
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_161520/func_15136A50.s")
 

--- a/conker/src/game_161520.c
+++ b/conker/src/game_161520.c
@@ -90,7 +90,8 @@ void func_1513477C(struct102 *arg0) {
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_161520/func_151347CC.s")
 
-#pragma GLOBAL_ASM("asm/nonmatchings/game_161520/func_151348F0.s")
+void func_151348F0(f32 arg0, f32 arg1, s32 arg2, s32 arg3) {
+}
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_161520/func_15134908.s")
 
@@ -98,7 +99,8 @@ void func_1513477C(struct102 *arg0) {
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_161520/func_15134C98.s")
 
-#pragma GLOBAL_ASM("asm/nonmatchings/game_161520/func_15134CD4.s")
+void func_15134CD4(f32 arg0, f32 arg1, s32 arg2, s32 arg3) {
+}
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_161520/func_15134CEC.s")
 

--- a/conker/src/game_161520.c
+++ b/conker/src/game_161520.c
@@ -2,6 +2,8 @@
 #include "functions.h"
 #include "variables.h"
 
+extern f32 D_800A4828;
+
 // requires jump table
 #pragma GLOBAL_ASM("asm/nonmatchings/game_161520/func_15134070.s")
 
@@ -180,7 +182,10 @@ s32 func_15136A1C(struct102 *arg0) {
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_161520/func_15137C64.s")
 
-#pragma GLOBAL_ASM("asm/nonmatchings/game_161520/func_15137E10.s")
+s32 func_15137E10(void *arg0) {
+    *(f32 *)((u8 *)arg0 + 0x74) = ((func_150ADA68() * 50.0f) + 580.0f) * D_800A4828;
+    return 1;
+}
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_161520/func_15137E60.s")
 

--- a/conker/src/game_161520.c
+++ b/conker/src/game_161520.c
@@ -106,9 +106,13 @@ void func_1513477C(struct102 *arg0) {
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_161520/func_15134E48.s")
 
-#pragma GLOBAL_ASM("asm/nonmatchings/game_161520/func_151352EC.s")
+void func_151352EC(struct102 *arg0) {
+    func_15169804(arg0);
+}
 
-#pragma GLOBAL_ASM("asm/nonmatchings/game_161520/func_1513530C.s")
+void func_1513530C(struct102 *arg0) {
+    func_15169824(arg0);
+}
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_161520/func_1513532C.s")
 

--- a/conker/src/game_161520.c
+++ b/conker/src/game_161520.c
@@ -130,10 +130,10 @@ void func_1513530C(struct102 *arg0) {
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_161520/func_151355B8.s")
 
-s32 func_15135658(void *arg0) {
+s32 func_15135658(struct259 *arg0) {
     s32 ret = 1;
 
-    *(f32 *)((u8 *)arg0 + 0x74) = 1.0f;
+    arg0->unk74 = 1.0f;
     return ret;
 }
 
@@ -182,8 +182,8 @@ s32 func_15136A1C(struct102 *arg0) {
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_161520/func_15137C64.s")
 
-s32 func_15137E10(void *arg0) {
-    *(f32 *)((u8 *)arg0 + 0x74) = ((func_150ADA68() * 50.0f) + 580.0f) * D_800A4828;
+s32 func_15137E10(struct259 *arg0) {
+    arg0->unk74 = ((func_150ADA68() * 50.0f) + 580.0f) * D_800A4828;
     return 1;
 }
 

--- a/conker/src/game_169510.c
+++ b/conker/src/game_169510.c
@@ -526,16 +526,25 @@ void func_1513F680(struct171 *arg0, u8 arg1, u8 arg2, u8 arg3, u8 arg4) {
     arg0->unk73 = arg4;
 }
 
-void func_1513F6C0(void *arg0, u8 arg1, u8 arg2) {
-    ((u8 *)arg0)[0x80] = arg1;
-    ((u8 *)arg0)[0x81] = arg2;
+void func_1513F6C0(struct210 *arg0, u8 arg1, u8 arg2) {
+    arg0->unk80 = arg1;
+    arg0->unk81 = arg2;
 }
 
-s32 func_1513F6E8(void *arg0) {
-    f32 value = *(f32 *)((u8 *)arg0 + 0x128);
+s32 func_1513F6E8(void *arg0_raw) {
+    typedef struct {
+        u8 pad0[0x2C];
+        f32 unk2C;
+        f32 unk30;
+        u8 pad34[0xF4];
+        f32 unk128;
+    } Game169510Motion;
 
-    *(f32 *)((u8 *)arg0 + 0x2C) += value * D_800BE9A4;
-    *(f32 *)((u8 *)arg0 + 0x30) += value * D_800BE9A4;
+    Game169510Motion *arg0 = (Game169510Motion *)arg0_raw;
+    f32 value = arg0->unk128;
+
+    arg0->unk2C += value * D_800BE9A4;
+    arg0->unk30 += value * D_800BE9A4;
     return 1;
 }
 

--- a/conker/src/game_169510.c
+++ b/conker/src/game_169510.c
@@ -526,7 +526,10 @@ void func_1513F680(struct171 *arg0, u8 arg1, u8 arg2, u8 arg3, u8 arg4) {
     arg0->unk73 = arg4;
 }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/game_169510/func_1513F6C0.s")
+void func_1513F6C0(void *arg0, u8 arg1, u8 arg2) {
+    ((u8 *)arg0)[0x80] = arg1;
+    ((u8 *)arg0)[0x81] = arg2;
+}
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_169510/func_1513F6E8.s")
 

--- a/conker/src/game_169510.c
+++ b/conker/src/game_169510.c
@@ -531,13 +531,33 @@ void func_1513F6C0(void *arg0, u8 arg1, u8 arg2) {
     ((u8 *)arg0)[0x81] = arg2;
 }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/game_169510/func_1513F6E8.s")
+s32 func_1513F6E8(void *arg0) {
+    f32 value = *(f32 *)((u8 *)arg0 + 0x128);
+
+    *(f32 *)((u8 *)arg0 + 0x2C) += value * D_800BE9A4;
+    *(f32 *)((u8 *)arg0 + 0x30) += value * D_800BE9A4;
+    return 1;
+}
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_169510/func_1513F728.s")
 
-#pragma GLOBAL_ASM("asm/nonmatchings/game_169510/func_1513FA2C.s")
+void func_1513FAB4(void *arg0, s32 arg1, f32 *arg2, s16 arg3);
 
-#pragma GLOBAL_ASM("asm/nonmatchings/game_169510/func_1513FA70.s")
+void func_1513FA2C(void *arg0, s16 arg1) {
+    f32 sp18[2];
+
+    sp18[0] = 1.0f;
+    sp18[1] = 1.0f;
+    func_1513FAB4(arg0, 0, sp18, arg1);
+}
+
+void func_1513FA70(void *arg0, s16 arg1) {
+    f32 sp18[2];
+
+    sp18[0] = 1.0f;
+    sp18[1] = 1.0f;
+    func_1513FAB4(arg0, 1, sp18, arg1);
+}
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_169510/func_1513FAB4.s")
 

--- a/conker/src/game_169510.c
+++ b/conker/src/game_169510.c
@@ -531,22 +531,23 @@ void func_1513F6C0(struct210 *arg0, u8 arg1, u8 arg2) {
     arg0->unk81 = arg2;
 }
 
-s32 func_1513F6E8(void *arg0_raw) {
-    typedef struct {
-        u8 pad0[0x2C];
-        f32 unk2C;
-        f32 unk30;
-        u8 pad34[0xF4];
-        f32 unk128;
-    } Game169510Motion;
-
-    Game169510Motion *arg0 = (Game169510Motion *)arg0_raw;
-    f32 value = arg0->unk128;
-
-    arg0->unk2C += value * D_800BE9A4;
-    arg0->unk30 += value * D_800BE9A4;
-    return 1;
-}
+// s32 func_1513F6E8(void *arg0_raw) {
+//     typedef struct {
+//         u8 pad0[0x2C];
+//         f32 unk2C;
+//         f32 unk30;
+//         u8 pad34[0xF4];
+//         f32 unk128;
+//     } Game169510Motion;
+//
+//     Game169510Motion *arg0 = (Game169510Motion *)arg0_raw;
+//     f32 value = arg0->unk128;
+//
+//     arg0->unk2C += value * D_800BE9A4;
+//     arg0->unk30 += value * D_800BE9A4;
+//     return 1;
+// }
+#pragma GLOBAL_ASM("asm/nonmatchings/game_169510/func_1513F6E8.s")
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_169510/func_1513F728.s")
 

--- a/conker/src/game_16DC80.c
+++ b/conker/src/game_16DC80.c
@@ -10,7 +10,19 @@ typedef struct {
     f32 unk8;
 } Game16DC80Vec3f;
 
-f32 func_1514182C(u8 *arg0, u8 *arg1, s32 arg2, f32 arg3, f32 arg4, f32 arg5);
+typedef struct {
+    u8 pad0[0x154];
+    volatile s32 unk154;
+    u8 pad158[0x10];
+    u8 unk168;
+    u8 pad169[0x7];
+    s32 unk170;
+    f32 unk174;
+    Game16DC80Vec3f *unk178;
+    Game16DC80Vec3f unk17C;
+} Game16DC80Obj;
+
+f32 func_1514182C(Game16DC80Obj *arg0, Game16DC80Vec3f *arg1, s32 arg2, f32 arg3, f32 arg4, f32 arg5);
 void func_1517E134(s32 arg0);
 extern s32 D_800DC9F0;
 extern void (*D_80089F9C[])(void *);
@@ -28,20 +40,20 @@ void func_151411C4(struct210 *arg0) {
     func_1513CAA0(arg0);
 }
 
-void func_151411E4(u8 *arg0) {
-    if (*(volatile s32 *)(arg0 + 0x154) != 0) {
-        func_1517E134(*(volatile s32 *)(arg0 + 0x154));
+void func_151411E4(Game16DC80Obj *arg0) {
+    if (arg0->unk154 != 0) {
+        func_1517E134(arg0->unk154);
     }
     D_800DC9F0--;
-    D_80089F9C[*(u8 *)(arg0 + 0x168)](arg0);
+    D_80089F9C[arg0->unk168](arg0);
 }
 
-void func_15141250(u8 *arg0) {
-    if (*(volatile s32 *)(arg0 + 0x154) != 0) {
-        func_1517E134(*(volatile s32 *)(arg0 + 0x154));
+void func_15141250(Game16DC80Obj *arg0) {
+    if (arg0->unk154 != 0) {
+        func_1517E134(arg0->unk154);
     }
     D_800DC9F0--;
-    D_80089FE4[*(u8 *)(arg0 + 0x168)](arg0);
+    D_80089FE4[arg0->unk168](arg0);
 }
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16DC80/func_151412BC.s")
@@ -87,10 +99,10 @@ s32 func_15141818(s32 arg0, s32 arg1) {
 //     return temp_f0;
 // }
 
-s32 func_15141928(u8 *arg0) {
+s32 func_15141928(Game16DC80Obj *arg0) {
     Game16DC80Vec3f *temp_v0;
 
-    temp_v0 = *(Game16DC80Vec3f **)(arg0 + 0x178);
-    func_1514182C(arg0, arg0 + 0x17C, *(s32 *)(arg0 + 0x170), *(f32 *)(arg0 + 0x174), temp_v0->unk0, temp_v0->unk8);
+    temp_v0 = arg0->unk178;
+    func_1514182C(arg0, &arg0->unk17C, arg0->unk170, arg0->unk174, temp_v0->unk0, temp_v0->unk8);
     return 1;
 }

--- a/conker/src/game_16DC80.c
+++ b/conker/src/game_16DC80.c
@@ -11,6 +11,10 @@ typedef struct {
 } Game16DC80Vec3f;
 
 f32 func_1514182C(u8 *arg0, u8 *arg1, s32 arg2, f32 arg3, f32 arg4, f32 arg5);
+void func_1517E134(s32 arg0);
+extern s32 D_800DC9F0;
+extern void (*D_80089F9C[])(void *);
+extern void (*D_80089FE4[])(void *);
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16DC80/func_151407D0.s")
 
@@ -24,9 +28,21 @@ void func_151411C4(struct210 *arg0) {
     func_1513CAA0(arg0);
 }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/game_16DC80/func_151411E4.s")
+void func_151411E4(u8 *arg0) {
+    if (*(volatile s32 *)(arg0 + 0x154) != 0) {
+        func_1517E134(*(volatile s32 *)(arg0 + 0x154));
+    }
+    D_800DC9F0--;
+    D_80089F9C[*(u8 *)(arg0 + 0x168)](arg0);
+}
 
-#pragma GLOBAL_ASM("asm/nonmatchings/game_16DC80/func_15141250.s")
+void func_15141250(u8 *arg0) {
+    if (*(volatile s32 *)(arg0 + 0x154) != 0) {
+        func_1517E134(*(volatile s32 *)(arg0 + 0x154));
+    }
+    D_800DC9F0--;
+    D_80089FE4[*(u8 *)(arg0 + 0x168)](arg0);
+}
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16DC80/func_151412BC.s")
 

--- a/conker/src/game_16DC80.c
+++ b/conker/src/game_16DC80.c
@@ -3,31 +3,6 @@
 #include "functions.h"
 #include "variables.h"
 
-
-typedef struct {
-    f32 unk0;
-    f32 unk4;
-    f32 unk8;
-} Game16DC80Vec3f;
-
-typedef struct {
-    u8 pad0[0x154];
-    volatile s32 unk154;
-    u8 pad158[0x10];
-    u8 unk168;
-    u8 pad169[0x7];
-    s32 unk170;
-    f32 unk174;
-    Game16DC80Vec3f *unk178;
-    Game16DC80Vec3f unk17C;
-} Game16DC80Obj;
-
-f32 func_1514182C(Game16DC80Obj *arg0, Game16DC80Vec3f *arg1, s32 arg2, f32 arg3, f32 arg4, f32 arg5);
-void func_1517E134(s32 arg0);
-extern s32 D_800DC9F0;
-extern void (*D_80089F9C[])(void *);
-extern void (*D_80089FE4[])(void *);
-
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16DC80/func_151407D0.s")
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16DC80/func_151408A4.s")
@@ -40,21 +15,23 @@ void func_151411C4(struct210 *arg0) {
     func_1513CAA0(arg0);
 }
 
-void func_151411E4(Game16DC80Obj *arg0) {
-    if (arg0->unk154 != 0) {
-        func_1517E134(arg0->unk154);
-    }
-    D_800DC9F0--;
-    D_80089F9C[arg0->unk168](arg0);
-}
+// void func_151411E4(Game16DC80Obj *arg0) {
+//     if (arg0->unk154 != 0) {
+//         func_1517E134(arg0->unk154);
+//     }
+//     D_800DC9F0--;
+//     D_80089F9C[arg0->unk168](arg0);
+// }
+#pragma GLOBAL_ASM("asm/nonmatchings/game_16DC80/func_151411E4.s")
 
-void func_15141250(Game16DC80Obj *arg0) {
-    if (arg0->unk154 != 0) {
-        func_1517E134(arg0->unk154);
-    }
-    D_800DC9F0--;
-    D_80089FE4[arg0->unk168](arg0);
-}
+// void func_15141250(Game16DC80Obj *arg0) {
+//     if (arg0->unk154 != 0) {
+//         func_1517E134(arg0->unk154);
+//     }
+//     D_800DC9F0--;
+//     D_80089FE4[arg0->unk168](arg0);
+// }
+#pragma GLOBAL_ASM("asm/nonmatchings/game_16DC80/func_15141250.s")
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16DC80/func_151412BC.s")
 
@@ -99,10 +76,11 @@ s32 func_15141818(s32 arg0, s32 arg1) {
 //     return temp_f0;
 // }
 
-s32 func_15141928(Game16DC80Obj *arg0) {
-    Game16DC80Vec3f *temp_v0;
-
-    temp_v0 = arg0->unk178;
-    func_1514182C(arg0, &arg0->unk17C, arg0->unk170, arg0->unk174, temp_v0->unk0, temp_v0->unk8);
-    return 1;
-}
+// s32 func_15141928(Game16DC80Obj *arg0) {
+//     Game16DC80Vec3f *temp_v0;
+//
+//     temp_v0 = arg0->unk178;
+//     func_1514182C(arg0, &arg0->unk17C, arg0->unk170, arg0->unk174, temp_v0->unk0, temp_v0->unk8);
+//     return 1;
+// }
+#pragma GLOBAL_ASM("asm/nonmatchings/game_16DC80/func_15141928.s")

--- a/conker/src/game_16DC80.c
+++ b/conker/src/game_16DC80.c
@@ -4,6 +4,14 @@
 #include "variables.h"
 
 
+typedef struct {
+    f32 unk0;
+    f32 unk4;
+    f32 unk8;
+} Game16DC80Vec3f;
+
+f32 func_1514182C(u8 *arg0, u8 *arg1, s32 arg2, f32 arg3, f32 arg4, f32 arg5);
+
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16DC80/func_151407D0.s")
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16DC80/func_151408A4.s")
@@ -63,9 +71,10 @@ s32 func_15141818(s32 arg0, s32 arg1) {
 //     return temp_f0;
 // }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/game_16DC80/func_15141928.s")
-// s32 func_15141928(void *arg0) {
-//     void *temp_v0 = arg0->unk178;
-//     func_1514182C(arg0, arg0->unk17C, arg0->unk170, arg0->unk174, temp_v0->unk0, temp_v0->unk8);
-//     return 1;
-// }
+s32 func_15141928(u8 *arg0) {
+    Game16DC80Vec3f *temp_v0;
+
+    temp_v0 = *(Game16DC80Vec3f **)(arg0 + 0x178);
+    func_1514182C(arg0, arg0 + 0x17C, *(s32 *)(arg0 + 0x170), *(f32 *)(arg0 + 0x174), temp_v0->unk0, temp_v0->unk8);
+    return 1;
+}

--- a/conker/src/game_16EE20.c
+++ b/conker/src/game_16EE20.c
@@ -99,19 +99,20 @@ s32 func_151422F8(s32 arg0, s32 arg1, s32 arg2, s32 arg3, s32 arg4) {
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15142838.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15142914.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_151429E0.s")
-s32 func_15142A5C(struct127 *arg0) {
-    typedef struct {
-        u8 pad0[0x3C];
-        s16 unk3C;
-    } struct197_local;
-
-    struct197_local *temp_v0 = (struct197_local *)arg0->unk2D0;
-
-    if (temp_v0->unk3C > 0) {
-        return 1;
-    }
-    return 0;
-}
+// s32 func_15142A5C(struct127 *arg0) {
+//     typedef struct {
+//         u8 pad0[0x3C];
+//         s16 unk3C;
+//     } struct197_local;
+//
+//     struct197_local *temp_v0 = (struct197_local *)arg0->unk2D0;
+//
+//     if (temp_v0->unk3C > 0) {
+//         return 1;
+//     }
+//     return 0;
+// }
+#pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15142A5C.s")
 f32 func_15142A80(f32 arg0) {
     return ((1.0f - arg0) * (arg0 - 2.0f) * arg0) * D_800A5624;
 }

--- a/conker/src/game_16EE20.c
+++ b/conker/src/game_16EE20.c
@@ -4,6 +4,8 @@
 #include "variables.h"
 
 
+extern f32 D_800A5624;
+
 void func_15141970(struct37 *arg0) {
     func_1514EDF0(arg0, arg0->unk2C);
 }
@@ -95,17 +97,30 @@ s32 func_151422F8(s32 arg0, s32 arg1, s32 arg2, s32 arg3, s32 arg4) {
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15142838.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15142914.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_151429E0.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15142A5C.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15142A80.s")
+s32 func_15142A5C(void *arg0) {
+    void *temp_v0 = *(void **)((u8 *)arg0 + 0x2D0);
+
+    if (*(s16 *)((u8 *)temp_v0 + 0x3C) > 0) {
+        return 1;
+    }
+    return 0;
+}
+f32 func_15142A80(f32 arg0) {
+    return ((1.0f - arg0) * (arg0 - 2.0f) * arg0) * D_800A5624;
+}
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15142AC0.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15142B04.s")
+f32 func_15142B04(f32 arg0) {
+    return ((2.0f - arg0) * (arg0 + 1.0f) * arg0) * 0.5f;
+}
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15142B44.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15142B7C.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15142C10.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15142CF0.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15142E24.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15142FBC.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15143044.s")
+s32 func_15143044(u8 arg0, s32 arg1) {
+    return (s16)(0x7FFF - arg0);
+}
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_1514306C.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15143134.s")
 

--- a/conker/src/game_16EE20.c
+++ b/conker/src/game_16EE20.c
@@ -5,6 +5,8 @@
 
 
 extern f32 D_800A5624;
+extern f32 D_800A5628;
+void func_15143794(s16 arg0, s16 arg1, f32 arg2);
 
 void func_15141970(struct37 *arg0) {
     func_1514EDF0(arg0, arg0->unk2C);
@@ -108,11 +110,15 @@ s32 func_15142A5C(void *arg0) {
 f32 func_15142A80(f32 arg0) {
     return ((1.0f - arg0) * (arg0 - 2.0f) * arg0) * D_800A5624;
 }
-#pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15142AC0.s")
+f32 func_15142AC0(f32 arg0) {
+    return ((arg0 + 1.0f) * (arg0 - 1.0f) * (arg0 - 2.0f)) * 0.5f;
+}
 f32 func_15142B04(f32 arg0) {
     return ((2.0f - arg0) * (arg0 + 1.0f) * arg0) * 0.5f;
 }
-#pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15142B44.s")
+f32 func_15142B44(f32 arg0) {
+    return ((arg0 + 1.0f) * (arg0 - 1.0f) * arg0) * D_800A5628;
+}
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15142B7C.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15142C10.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15142CF0.s")
@@ -180,7 +186,9 @@ s32 func_15143044(u8 arg0, s32 arg1) {
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_151436B4.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_1514373C.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15143794.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15143834.s")
+void func_15143834(s16 arg0, s16 arg1, f32 arg2) {
+    func_15143794(arg0, arg1, arg2);
+}
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15143874.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_151438D8.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15143D18.s")
@@ -191,7 +199,13 @@ s32 func_15143E08(struct127 *arg0) {
 }
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15143E24.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15143E64.s")
+f32 func_15143E64(f32 *arg0) {
+    f32 x = arg0[0];
+    f32 y = arg0[1];
+    f32 z = arg0[2];
+
+    return sqrtf((x * x) + (y * y) + (z * z));
+}
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15143E94.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_1514401C.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_151441A4.s")
@@ -203,7 +217,9 @@ s32 func_15143E08(struct127 *arg0) {
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_1514470C.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15144A74.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15144AA8.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15144B34.s")
+void *func_15144B34(s32 arg0) {
+    return (u8 *)&D_800DBFF0[arg0] + 0x2F8;
+}
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15144B68.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15144BC8.s")
 

--- a/conker/src/game_16EE20.c
+++ b/conker/src/game_16EE20.c
@@ -99,10 +99,15 @@ s32 func_151422F8(s32 arg0, s32 arg1, s32 arg2, s32 arg3, s32 arg4) {
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15142838.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15142914.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_151429E0.s")
-s32 func_15142A5C(void *arg0) {
-    void *temp_v0 = *(void **)((u8 *)arg0 + 0x2D0);
+s32 func_15142A5C(struct127 *arg0) {
+    typedef struct {
+        u8 pad0[0x3C];
+        s16 unk3C;
+    } struct197_local;
 
-    if (*(s16 *)((u8 *)temp_v0 + 0x3C) > 0) {
+    struct197_local *temp_v0 = (struct197_local *)arg0->unk2D0;
+
+    if (temp_v0->unk3C > 0) {
         return 1;
     }
     return 0;
@@ -217,8 +222,8 @@ f32 func_15143E64(f32 *arg0) {
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_1514470C.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15144A74.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15144AA8.s")
-void *func_15144B34(s32 arg0) {
-    return (u8 *)&D_800DBFF0[arg0] + 0x2F8;
+f32 *func_15144B34(s32 arg0) {
+    return &D_800DBFF0[arg0].unk2F8;
 }
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15144B68.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_16EE20/func_15144BC8.s")

--- a/conker/src/game_1897A0.c
+++ b/conker/src/game_1897A0.c
@@ -47,32 +47,33 @@
 //     return 1;
 // }
 
-s32 func_1515D030(u8 *arg0_raw, s32 arg1) {
-    typedef struct {
-        u8 pad0[0x25];
-        u8 unk25;
-        u8 pad26[0x6];
-        s8 unk2C;
-        u8 pad2D;
-        s8 unk2E;
-    } Game1897A0Ring;
-
-    Game1897A0Ring *arg0;
-    s32 ret;
-
-    arg0 = (Game1897A0Ring *)arg0_raw;
-    ret = 1;
-    if (arg0->unk2C >= 3) {
-        arg0->unk2C = arg0->unk2C - 1;
-        arg0->unk2E = arg0->unk2E - 1;
-        if (arg0->unk2E < 0) {
-            arg0->unk2E = arg0->unk25 - 1;
-        }
-    } else {
-        ret = 0;
-    }
-    return ret;
-}
+// s32 func_1515D030(u8 *arg0_raw, s32 arg1) {
+//     typedef struct {
+//         u8 pad0[0x25];
+//         u8 unk25;
+//         u8 pad26[0x6];
+//         s8 unk2C;
+//         u8 pad2D;
+//         s8 unk2E;
+//     } Game1897A0Ring;
+//
+//     Game1897A0Ring *arg0;
+//     s32 ret;
+//
+//     arg0 = (Game1897A0Ring *)arg0_raw;
+//     ret = 1;
+//     if (arg0->unk2C >= 3) {
+//         arg0->unk2C = arg0->unk2C - 1;
+//         arg0->unk2E = arg0->unk2E - 1;
+//         if (arg0->unk2E < 0) {
+//             arg0->unk2E = arg0->unk25 - 1;
+//         }
+//     } else {
+//         ret = 0;
+//     }
+//     return ret;
+// }
+#pragma GLOBAL_ASM("asm/nonmatchings/game_1897A0/func_1515D030.s")
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1897A0/func_1515D088.s")
 // s32 func_1515D088(void *arg0) {

--- a/conker/src/game_1897A0.c
+++ b/conker/src/game_1897A0.c
@@ -47,15 +47,26 @@
 //     return 1;
 // }
 
-s32 func_1515D030(u8 *arg0, s32 arg1) {
+s32 func_1515D030(u8 *arg0_raw, s32 arg1) {
+    typedef struct {
+        u8 pad0[0x25];
+        u8 unk25;
+        u8 pad26[0x6];
+        s8 unk2C;
+        u8 pad2D;
+        s8 unk2E;
+    } Game1897A0Ring;
+
+    Game1897A0Ring *arg0;
     s32 ret;
 
+    arg0 = (Game1897A0Ring *)arg0_raw;
     ret = 1;
-    if (*(s8 *)(arg0 + 0x2C) >= 3) {
-        *(s8 *)(arg0 + 0x2C) = *(s8 *)(arg0 + 0x2C) - 1;
-        *(s8 *)(arg0 + 0x2E) = *(s8 *)(arg0 + 0x2E) - 1;
-        if (*(s8 *)(arg0 + 0x2E) < 0) {
-            *(s8 *)(arg0 + 0x2E) = *(u8 *)(arg0 + 0x25) - 1;
+    if (arg0->unk2C >= 3) {
+        arg0->unk2C = arg0->unk2C - 1;
+        arg0->unk2E = arg0->unk2E - 1;
+        if (arg0->unk2E < 0) {
+            arg0->unk2E = arg0->unk25 - 1;
         }
     } else {
         ret = 0;

--- a/conker/src/game_1897A0.c
+++ b/conker/src/game_1897A0.c
@@ -47,25 +47,21 @@
 //     return 1;
 // }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/game_1897A0/func_1515D030.s")
-// s32 func_1515D030(void *arg0, ? arg1) {
-//     s8 temp_v0;
-//     s32 phi_v1;
-//
-//     temp_v0 = arg0->unk2C;
-//     if ((s32) temp_v0 >= 3) {
-//         arg0->unk2C = (s8) (temp_v0 - 1);
-//         arg0->unk2E = (s8) (arg0->unk2E - 1);
-//         phi_v1 = 1;
-//         if ((s32) arg0->unk2E < 0) {
-//             arg0->unk2E = (s8) (arg0->unk25 - 1);
-//             phi_v1 = 1;
-//         }
-//     } else {
-//         phi_v1 = 0;
-//     }
-//     return phi_v1;
-// }
+s32 func_1515D030(u8 *arg0, s32 arg1) {
+    s32 ret;
+
+    ret = 1;
+    if (*(s8 *)(arg0 + 0x2C) >= 3) {
+        *(s8 *)(arg0 + 0x2C) = *(s8 *)(arg0 + 0x2C) - 1;
+        *(s8 *)(arg0 + 0x2E) = *(s8 *)(arg0 + 0x2E) - 1;
+        if (*(s8 *)(arg0 + 0x2E) < 0) {
+            *(s8 *)(arg0 + 0x2E) = *(u8 *)(arg0 + 0x25) - 1;
+        }
+    } else {
+        ret = 0;
+    }
+    return ret;
+}
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1897A0/func_1515D088.s")
 // s32 func_1515D088(void *arg0) {

--- a/conker/src/game_1944C0.c
+++ b/conker/src/game_1944C0.c
@@ -175,7 +175,7 @@ s32 func_15169668(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
 }
 void func_1516968C(void *arg0, u8 *arg1, u8 arg2) {
     if ((arg2 == 0xF) || (arg2 == 0x10)) {
-        if (*arg1 == *(u8 *)((u8 *)arg0 + 0xC)) {
+        if (*arg1 == ((u8 *)arg0)[0xC]) {
             func_1516972C(arg0);
         }
     }

--- a/conker/src/game_1944C0.c
+++ b/conker/src/game_1944C0.c
@@ -4,6 +4,9 @@
 #include "variables.h"
 
 
+void func_15168B10(s32 arg0, s32 arg1);
+extern u8 D_800D2DAB;
+
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_15167010.s")
 // NON-MATCHING: not hugely far away
 // void func_15167010(void) {
@@ -34,7 +37,9 @@
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_1516865C.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_15168800.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_15168870.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_15168A2C.s")
+void func_15168A2C(s32 arg0) {
+    func_15168B10(arg0, 0);
+}
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_15168A4C.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_15168A9C.s")
 // void *func_15168A9C(struct12 *arg0) {
@@ -67,7 +72,13 @@ void func_15168B10(s32 arg0, s32 arg1) {
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_15168BAC.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_15168BE4.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_15168C4C.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_15168E34.s")
+void func_15168E34(u32 *arg0, u32 arg1) {
+    u32 value = *arg0;
+
+    if ((value & 0x0F000000) == 0) {
+        *arg0 = value + arg1;
+    }
+}
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_15168E54.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_15168F08.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_15168F84.s")
@@ -77,7 +88,10 @@ void func_15168B10(s32 arg0, s32 arg1) {
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_1516944C.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_151695F0.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_1516962C.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_15169668.s")
+s32 func_15169668(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
+    D_800D2DAB = 1;
+    return arg0;
+}
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_1516968C.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_151696DC.s")
 

--- a/conker/src/game_1944C0.c
+++ b/conker/src/game_1944C0.c
@@ -71,20 +71,37 @@ void func_15168B10(s32 arg0, s32 arg1) {
 }
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_15168B44.s")
-void func_15168BAC(void *arg0) {
-    u8 idx = *(u8 *)((u8 *)arg0 + 0xE4);
+void func_15168BAC(void *arg0_raw) {
+    typedef struct {
+        u8 pad0[0xE4];
+        u8 unkE4;
+    } Game1944C0Dispatch;
+
+    Game1944C0Dispatch *arg0 = (Game1944C0Dispatch *)arg0_raw;
+    u8 idx = arg0->unkE4;
 
     if (idx != 0) {
         D_8008CA20[idx](arg0);
     }
 }
-void func_15168BE4(u8 *arg0, u8 arg1, s32 arg2) {
-    void *temp_v0;
+void func_15168BE4(void *arg0_raw, u8 arg1, s32 arg2) {
+    typedef struct {
+        u8 pad0[0x40];
+        s32 unk40;
+    } Game1944C0CopySrc;
 
-    if (*(s32 *)(arg0 + 0x40) != 0) {
+    typedef struct {
+        u8 pad0[0x90];
+        u8 unk90[0x60];
+    } Game1944C0CopyDst;
+
+    Game1944C0CopySrc *arg0 = (Game1944C0CopySrc *)arg0_raw;
+    Game1944C0CopyDst *temp_v0;
+
+    if (arg0->unk40 != 0) {
         temp_v0 = func_15167A68(0x10, arg2, 0xF0, 1, arg1, 1);
         if (temp_v0 != NULL) {
-            bcopy(arg0, (u8 *)temp_v0 + 0x90, 0x60);
+            bcopy(arg0, temp_v0->unk90, 0x60);
         }
     }
 }
@@ -138,13 +155,18 @@ void func_15168F84(s32 arg0, s32 *arg1, s32 *arg2) {
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_1516944C.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_151695F0.s")
 void func_1516962C(s32 arg0, void *arg1, u8 arg2) {
+    typedef struct {
+        u8 pad0[0x3B];
+        u8 unk3B;
+    } Game1944C0Payload;
+
     struct {
         void *unk0;
         u8 unk4;
     } sp18;
 
     sp18.unk0 = arg1;
-    sp18.unk4 = *(u8 *)((u8 *)arg1 + 0x3B);
+    sp18.unk4 = ((Game1944C0Payload *)arg1)->unk3B;
     func_1516944C(arg0, (s32)&sp18, arg2);
 }
 s32 func_15169668(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
@@ -158,12 +180,12 @@ void func_1516968C(void *arg0, u8 *arg1, u8 arg2) {
         }
     }
 }
-void func_151696DC(void *arg0) {
+void func_151696DC(struct102 *arg0) {
     s32 i;
 
     for (i = 0; i < D_800DD190; i = (s8)(i + 1)) {
         if (arg0 == ((void **)D_800DD198)[i]) {
-            ((void **)D_800DD198)[i] = *(void **)((u8 *)arg0 + 8);
+            ((void **)D_800DD198)[i] = (void *)arg0->unk8;
         }
     }
 }

--- a/conker/src/game_1944C0.c
+++ b/conker/src/game_1944C0.c
@@ -88,13 +88,55 @@ void func_15168E34(u32 *arg0, u32 arg1) {
 }
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_15168E54.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_15168F08.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_15168F84.s")
+void func_15168F84(s32 arg0, s32 *arg1, s32 *arg2) {
+    if (arg0 == 0) {
+        *arg1 = 1;
+        *arg2 = 0x41;
+        return;
+    }
+    if (arg0 == 1) {
+        *arg1 = 0x42;
+        *arg2 = 0x4F;
+        return;
+    }
+    if (arg0 == 2) {
+        *arg1 = 0x50;
+        *arg2 = 0x58;
+        return;
+    }
+    if (arg0 == 3) {
+        *arg1 = 0x59;
+        *arg2 = 0x5C;
+        return;
+    }
+    if (arg0 == 5) {
+        *arg1 = 0x61;
+        *arg2 = 0x63;
+        return;
+    }
+    if (arg0 == 6) {
+        *arg1 = 0x64;
+        *arg2 = 0x65;
+        return;
+    }
+    *arg1 = 0x5D;
+    *arg2 = 0x60;
+}
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_15169040.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_15169070.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_15169260.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_1516944C.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_151695F0.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_1516962C.s")
+void func_1516962C(s32 arg0, void *arg1, u8 arg2) {
+    struct {
+        void *unk0;
+        u8 unk4;
+    } sp18;
+
+    sp18.unk0 = arg1;
+    sp18.unk4 = *(u8 *)((u8 *)arg1 + 0x3B);
+    func_1516944C(arg0, (s32)&sp18, arg2);
+}
 s32 func_15169668(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
     D_800D2DAB = 1;
     return arg0;

--- a/conker/src/game_1944C0.c
+++ b/conker/src/game_1944C0.c
@@ -6,6 +6,7 @@
 
 void func_15168B10(s32 arg0, s32 arg1);
 extern u8 D_800D2DAB;
+extern void (*D_8008CA20[])(void *);
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_15167010.s")
 // NON-MATCHING: not hugely far away
@@ -69,7 +70,13 @@ void func_15168B10(s32 arg0, s32 arg1) {
 }
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_15168B44.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_15168BAC.s")
+void func_15168BAC(void *arg0) {
+    u8 idx = *(u8 *)((u8 *)arg0 + 0xE4);
+
+    if (idx != 0) {
+        D_8008CA20[idx](arg0);
+    }
+}
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_15168BE4.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_15168C4C.s")
 void func_15168E34(u32 *arg0, u32 arg1) {
@@ -92,7 +99,13 @@ s32 func_15169668(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
     D_800D2DAB = 1;
     return arg0;
 }
-#pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_1516968C.s")
+void func_1516968C(void *arg0, u8 *arg1, u8 arg2) {
+    if ((arg2 == 0xF) || (arg2 == 0x10)) {
+        if (*arg1 == *(u8 *)((u8 *)arg0 + 0xC)) {
+            func_1516972C(arg0);
+        }
+    }
+}
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_151696DC.s")
 
 void func_1516972C(struct102 *arg0) {

--- a/conker/src/game_1944C0.c
+++ b/conker/src/game_1944C0.c
@@ -5,6 +5,7 @@
 
 
 void func_15168B10(s32 arg0, s32 arg1);
+void *func_15167A68(s32 arg0, s32 arg1, s32 arg2, s32 arg3, u8 arg4, s32 arg5);
 extern u8 D_800D2DAB;
 extern void (*D_8008CA20[])(void *);
 
@@ -77,7 +78,16 @@ void func_15168BAC(void *arg0) {
         D_8008CA20[idx](arg0);
     }
 }
-#pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_15168BE4.s")
+void func_15168BE4(u8 *arg0, u8 arg1, s32 arg2) {
+    void *temp_v0;
+
+    if (*(s32 *)(arg0 + 0x40) != 0) {
+        temp_v0 = func_15167A68(0x10, arg2, 0xF0, 1, arg1, 1);
+        if (temp_v0 != NULL) {
+            bcopy(arg0, (u8 *)temp_v0 + 0x90, 0x60);
+        }
+    }
+}
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_15168C4C.s")
 void func_15168E34(u32 *arg0, u32 arg1) {
     u32 value = *arg0;
@@ -148,11 +158,19 @@ void func_1516968C(void *arg0, u8 *arg1, u8 arg2) {
         }
     }
 }
-#pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_151696DC.s")
+void func_151696DC(void *arg0) {
+    s32 i;
+
+    for (i = 0; i < D_800DD190; i = (s8)(i + 1)) {
+        if (arg0 == ((void **)D_800DD198)[i]) {
+            ((void **)D_800DD198)[i] = *(void **)((u8 *)arg0 + 8);
+        }
+    }
+}
 
 void func_1516972C(struct102 *arg0) {
     void (*func)(struct102 *arg0);
-    func_151696DC();
+    func_151696DC(arg0);
 
     if (arg0->unk0 >= 2) {
         func = D_8008B4D0[arg0->unk0].unk0;
@@ -167,7 +185,7 @@ void func_1516972C(struct102 *arg0) {
 void func_1516979C(struct102 *arg0) {
     void (*func)(struct102 *arg0);
 
-    func_151696DC();
+    func_151696DC(arg0);
     func = D_8008B4D4[arg0->unk0].unk0;
     if (func != NULL) {
         func(arg0);

--- a/conker/src/game_1944C0.c
+++ b/conker/src/game_1944C0.c
@@ -7,7 +7,6 @@
 void func_15168B10(s32 arg0, s32 arg1);
 void *func_15167A68(s32 arg0, s32 arg1, s32 arg2, s32 arg3, u8 arg4, s32 arg5);
 extern u8 D_800D2DAB;
-extern void (*D_8008CA20[])(void *);
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_15167010.s")
 // NON-MATCHING: not hugely far away
@@ -71,40 +70,43 @@ void func_15168B10(s32 arg0, s32 arg1) {
 }
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_15168B44.s")
-void func_15168BAC(void *arg0_raw) {
-    typedef struct {
-        u8 pad0[0xE4];
-        u8 unkE4;
-    } Game1944C0Dispatch;
+// void func_15168BAC(void *arg0_raw) {
+//     typedef struct {
+//         u8 pad0[0xE4];
+//         u8 unkE4;
+//     } Game1944C0Dispatch;
+//
+//     Game1944C0Dispatch *arg0 = (Game1944C0Dispatch *)arg0_raw;
+//     u8 idx = arg0->unkE4;
+//
+//     if (idx != 0) {
+//         D_8008CA20[idx](arg0);
+//     }
+// }
+#pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_15168BAC.s")
 
-    Game1944C0Dispatch *arg0 = (Game1944C0Dispatch *)arg0_raw;
-    u8 idx = arg0->unkE4;
-
-    if (idx != 0) {
-        D_8008CA20[idx](arg0);
-    }
-}
-void func_15168BE4(void *arg0_raw, u8 arg1, s32 arg2) {
-    typedef struct {
-        u8 pad0[0x40];
-        s32 unk40;
-    } Game1944C0CopySrc;
-
-    typedef struct {
-        u8 pad0[0x90];
-        u8 unk90[0x60];
-    } Game1944C0CopyDst;
-
-    Game1944C0CopySrc *arg0 = (Game1944C0CopySrc *)arg0_raw;
-    Game1944C0CopyDst *temp_v0;
-
-    if (arg0->unk40 != 0) {
-        temp_v0 = func_15167A68(0x10, arg2, 0xF0, 1, arg1, 1);
-        if (temp_v0 != NULL) {
-            bcopy(arg0, temp_v0->unk90, 0x60);
-        }
-    }
-}
+// void func_15168BE4(void *arg0_raw, u8 arg1, s32 arg2) {
+//     typedef struct {
+//         u8 pad0[0x40];
+//         s32 unk40;
+//     } Game1944C0CopySrc;
+//
+//     typedef struct {
+//         u8 pad0[0x90];
+//         u8 unk90[0x60];
+//     } Game1944C0CopyDst;
+//
+//     Game1944C0CopySrc *arg0 = (Game1944C0CopySrc *)arg0_raw;
+//     Game1944C0CopyDst *temp_v0;
+//
+//     if (arg0->unk40 != 0) {
+//         temp_v0 = func_15167A68(0x10, arg2, 0xF0, 1, arg1, 1);
+//         if (temp_v0 != NULL) {
+//             bcopy(arg0, temp_v0->unk90, 0x60);
+//         }
+//     }
+// }
+#pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_15168BE4.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_15168C4C.s")
 void func_15168E34(u32 *arg0, u32 arg1) {
     u32 value = *arg0;
@@ -154,41 +156,45 @@ void func_15168F84(s32 arg0, s32 *arg1, s32 *arg2) {
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_15169260.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_1516944C.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_151695F0.s")
-void func_1516962C(s32 arg0, void *arg1, u8 arg2) {
-    typedef struct {
-        u8 pad0[0x3B];
-        u8 unk3B;
-    } Game1944C0Payload;
-
-    struct {
-        void *unk0;
-        u8 unk4;
-    } sp18;
-
-    sp18.unk0 = arg1;
-    sp18.unk4 = ((Game1944C0Payload *)arg1)->unk3B;
-    func_1516944C(arg0, (s32)&sp18, arg2);
-}
+// void func_1516962C(s32 arg0, void *arg1, u8 arg2) {
+//     typedef struct {
+//         u8 pad0[0x3B];
+//         u8 unk3B;
+//     } Game1944C0Payload;
+//
+//     struct {
+//         void *unk0;
+//         u8 unk4;
+//     } sp18;
+//
+//     sp18.unk0 = arg1;
+//     sp18.unk4 = ((Game1944C0Payload *)arg1)->unk3B;
+//     func_1516944C(arg0, (s32)&sp18, arg2);
+// }
+#pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_1516962C.s")
 s32 func_15169668(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
     D_800D2DAB = 1;
     return arg0;
 }
-void func_1516968C(void *arg0, u8 *arg1, u8 arg2) {
-    if ((arg2 == 0xF) || (arg2 == 0x10)) {
-        if (*arg1 == ((u8 *)arg0)[0xC]) {
-            func_1516972C(arg0);
-        }
-    }
-}
-void func_151696DC(struct102 *arg0) {
-    s32 i;
+// void func_1516968C(void *arg0, u8 *arg1, u8 arg2) {
+//     if ((arg2 == 0xF) || (arg2 == 0x10)) {
+//         if (*arg1 == ((u8 *)arg0)[0xC]) {
+//             func_1516972C(arg0);
+//         }
+//     }
+// }
+#pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_1516968C.s")
 
-    for (i = 0; i < D_800DD190; i = (s8)(i + 1)) {
-        if (arg0 == ((void **)D_800DD198)[i]) {
-            ((void **)D_800DD198)[i] = (void *)arg0->unk8;
-        }
-    }
-}
+// void func_151696DC(struct102 *arg0) {
+//     s32 i;
+//
+//     for (i = 0; i < D_800DD190; i = (s8)(i + 1)) {
+//         if (arg0 == ((void **)D_800DD198)[i]) {
+//             ((void **)D_800DD198)[i] = (void *)arg0->unk8;
+//         }
+//     }
+// }
+#pragma GLOBAL_ASM("asm/nonmatchings/game_1944C0/func_151696DC.s")
 
 void func_1516972C(struct102 *arg0) {
     void (*func)(struct102 *arg0);

--- a/conker/src/game_30E90.c
+++ b/conker/src/game_30E90.c
@@ -20,14 +20,15 @@ void func_150045BC(void) {
 #pragma GLOBAL_ASM("asm/nonmatchings/game_30E90/func_150045C4.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_30E90/func_150049A4.s")
 
-void func_15004A4C(void) {
-    s32 i;
-
-    for (i = 0; i < D_800DBEF0; i++) {
-        ((s32 *)D_800DBEF8[0])[i] = 0;
-        ((s8 *)*((s32 *)D_800DBEFC))[i] = 0;
-    }
-}
+// void func_15004A4C(void) {
+//     s32 i;
+//
+//     for (i = 0; i < D_800DBEF0; i++) {
+//         ((s32 *)D_800DBEF8[0])[i] = 0;
+//         ((s8 *)*((s32 *)D_800DBEFC))[i] = 0;
+//     }
+// }
+#pragma GLOBAL_ASM("asm/nonmatchings/game_30E90/func_15004A4C.s")
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_30E90/func_15004AAC.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_30E90/func_15004BF0.s")

--- a/conker/src/game_30E90.c
+++ b/conker/src/game_30E90.c
@@ -19,15 +19,15 @@ void func_150045BC(void) {
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_30E90/func_150045C4.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_30E90/func_150049A4.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_30E90/func_15004A4C.s")
-// NON-MATCHING: not this...
-// void func_15004A4C(void) {
-//     u32 i;
-//     for (i = 0; i < D_800DBEF0; i++) {
-//         D_800DBEFC[i] = D_800DBEF8[i] = 0;
-//         // D_800DBEFC[i] = 0;
-//     }
-// }
+
+void func_15004A4C(void) {
+    s32 i;
+
+    for (i = 0; i < D_800DBEF0; i++) {
+        ((s32 *)D_800DBEF8[0])[i] = 0;
+        ((s8 *)*((s32 *)D_800DBEFC))[i] = 0;
+    }
+}
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_30E90/func_15004AAC.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_30E90/func_15004BF0.s")

--- a/conker/src/game_40490.c
+++ b/conker/src/game_40490.c
@@ -146,22 +146,23 @@ s32 func_1501407C(s32 arg0) {
 #pragma GLOBAL_ASM("asm/nonmatchings/game_40490/func_15014144.s")
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_40490/func_15014220.s")
-s32 func_150142AC(struct134 *arg0) {
-    typedef struct {
-        u8 pad0[0x1B];
-        u8 unk1B;
-    } struct134_local;
-
-    s32 idx;
-
-    arg0->unk16 |= 4;
-    idx = ((struct134_local *)arg0)->unk1B;
-    if ((idx < 0) || (idx >= 3)) {
-        return 1;
-    }
-    D_800D9AA0[idx] = arg0;
-    return 1;
-}
+// s32 func_150142AC(struct134 *arg0) {
+//     typedef struct {
+//         u8 pad0[0x1B];
+//         u8 unk1B;
+//     } struct134_local;
+//
+//     s32 idx;
+//
+//     arg0->unk16 |= 4;
+//     idx = ((struct134_local *)arg0)->unk1B;
+//     if ((idx < 0) || (idx >= 3)) {
+//         return 1;
+//     }
+//     D_800D9AA0[idx] = arg0;
+//     return 1;
+// }
+#pragma GLOBAL_ASM("asm/nonmatchings/game_40490/func_150142AC.s")
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_40490/func_150142EC.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_40490/func_150144B8.s")

--- a/conker/src/game_40490.c
+++ b/conker/src/game_40490.c
@@ -147,10 +147,15 @@ s32 func_1501407C(s32 arg0) {
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_40490/func_15014220.s")
 s32 func_150142AC(struct134 *arg0) {
+    typedef struct {
+        u8 pad0[0x1B];
+        u8 unk1B;
+    } struct134_local;
+
     s32 idx;
 
     arg0->unk16 |= 4;
-    idx = *(u8 *)((u8 *)arg0 + 0x1B);
+    idx = ((struct134_local *)arg0)->unk1B;
     if ((idx < 0) || (idx >= 3)) {
         return 1;
     }

--- a/conker/src/game_40490.c
+++ b/conker/src/game_40490.c
@@ -146,7 +146,17 @@ s32 func_1501407C(s32 arg0) {
 #pragma GLOBAL_ASM("asm/nonmatchings/game_40490/func_15014144.s")
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_40490/func_15014220.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_40490/func_150142AC.s")
+s32 func_150142AC(struct134 *arg0) {
+    s32 idx;
+
+    arg0->unk16 |= 4;
+    idx = *(u8 *)((u8 *)arg0 + 0x1B);
+    if ((idx < 0) || (idx >= 3)) {
+        return 1;
+    }
+    D_800D9AA0[idx] = arg0;
+    return 1;
+}
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_40490/func_150142EC.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_40490/func_150144B8.s")

--- a/conker/src/game_981E0.c
+++ b/conker/src/game_981E0.c
@@ -1449,7 +1449,10 @@ void func_15072AF8(void) {
 }
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_981E0/func_15072B44.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_981E0/func_15072DA0.s")
+void func_15072DA0(void) {
+    *(u16 *)((u8 *)D_800D154C + 0x2F8) &= 0xFFF8;
+    *(u16 *)((u8 *)D_800D154C + 0x2F8) |= D_800D1580;
+}
 
 void func_15072DD8(void) {
     func_15083568(D_800D154C, D_800D1580, 1.0f, 0);

--- a/conker/src/game_981E0.c
+++ b/conker/src/game_981E0.c
@@ -1450,8 +1450,8 @@ void func_15072AF8(void) {
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_981E0/func_15072B44.s")
 void func_15072DA0(void) {
-    *(u16 *)((u8 *)D_800D154C + 0x2F8) &= 0xFFF8;
-    *(u16 *)((u8 *)D_800D154C + 0x2F8) |= D_800D1580;
+    D_800D154C->unk2F8 &= 0xFFF8;
+    D_800D154C->unk2F8 |= D_800D1580;
 }
 
 void func_15072DD8(void) {


### PR DESCRIPTION
## Summary
- Converts 36 small `game` section stubs from `GLOBAL_ASM` to matching C.
- Adds splat/asm compatibility macros for newer generated directives.

## Verification
- `docker run --rm -v "$PWD":/conker -w /conker/conker conker bash -lc 'make --jobs'`
- `docker run --rm -v "$PWD":/conker -w /conker conker bash -lc 'make -C conker replace && make --jobs'`
- `docker run --rm -v "$PWD":/conker -w /conker/conker conker bash -lc 'make progress'`

Final ROM rebuild passed with `build/conker.us.z64: OK`.