### PR TITLE
Match functions in game-20xx-5Fxx

### DIFF
--- a/conker/src/game_2062D0.c
+++ b/conker/src/game_2062D0.c
@@ -3,6 +3,60 @@
 #include "functions.h"
 #include "variables.h"
 
+extern f32 D_800AB4B0; // 1.299999952f
+extern f32 D_800AB49C;
+
+// File-local description of the (still unnamed) object passed to the
+// func_151DA6A8 / func_151DADA0 family. structs.h has no entry for it yet.
+typedef struct {
+    /* 0x000 */ char pad000[0x10];
+    /* 0x010 */ f32 unk010;
+    /* 0x014 */ f32 unk014;
+    /* 0x018 */ char pad018[0x8];
+} Struct2062D0Sub;
+
+typedef struct {
+    /* 0x00 */ u8 unk00;
+    /* 0x01 */ s8 unk01;
+    /* 0x02 */ char pad02[0x2];
+    /* 0x04 */ f32 unk04;
+    /* 0x08 */ f32 unk08;
+} Struct2062D0Sub110;
+
+typedef struct {
+    /* 0x000 */ char pad000[0x4C];
+    /* 0x04C */ f32 unk04C;
+    /* 0x050 */ f32 unk050;
+    /* 0x054 */ char pad054[0x4];
+    /* 0x058 */ s32 unk058;
+    /* 0x05C */ char pad05C[0x110 - 0x5C];
+    /* 0x110 */ Struct2062D0Sub110 unk110;
+    /* 0x11C */ char pad11C[0x128 - 0x11C];
+    /* 0x128 */ Struct2062D0Sub unk128;
+} Struct2062D0;
+
+
+typedef struct {
+    /* 0x00 */ f32 unk00;
+    /* 0x04 */ u8 unk04;
+    /* 0x05 */ u8 unk05;
+    /* 0x06 */ s8 unk06;
+    /* 0x07 */ s8 unk07;
+    /* 0x08 */ f32 unk08;
+    /* 0x0C */ f32 unk0C;
+} Struct9450Sub;
+
+typedef struct {
+    /* 0x000 */ char pad000[0x38];
+    /* 0x038 */ f32 unk38;
+    /* 0x03C */ f32 unk3C;
+    /* 0x040 */ char pad040[0xA8 - 0x40];
+    /* 0x0A8 */ Struct9450Sub unkA8;
+    /* 0x0B8 */ char pad0B8[0xC1 - 0xB8];
+    /* 0x0C1 */ u8 unkC1;
+} Struct9450;
+
+s32 func_151D9450(Struct9450 *arg0, void *arg1);
 
 u8 func_151D8E20(void) {
     if ((D_800BE9F0 == 0) && (func_150A29C8(0, 0x1C) == 0)) {
@@ -84,7 +138,7 @@ u8 func_151D8FE0(void) {
 }
 
 // big struct definition
-// void func_151D9014(void *arg0, f32 *arg1, u8 arg2, f32 arg3, s16 arg4, u8 arg5, f32 arg6, u8 arg7, f32 arg8, f32 arg9, u8 argA, s32 argB, u8 argC, u8 argD, u8 argE, s32 argF);
+void func_151D9014(void *arg0, f32 *arg1, u8 arg2, f32 arg3, s16 arg4, u8 arg5, f32 arg6, u8 arg7, f32 arg8, f32 arg9, u8 argA, s32 argB, u8 argC, u8 argD, u8 argE, s32 argF);
 #pragma GLOBAL_ASM("asm/nonmatchings/game_2062D0/func_151D9014.s")
 
 s32 func_151D93F4(void *arg0, void *arg1) {
@@ -102,7 +156,67 @@ s32 func_151D93F4(void *arg0, void *arg1) {
     return res;
 }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/game_2062D0/func_151D9450.s")
+s32 func_151D9450(Struct9450 *arg0, void *arg1) {
+    Struct9450Sub *p;
+
+    p = &arg0->unkA8;
+    if (arg0->unkC1 & 1) {
+        return 1;
+    }
+    p->unk04 += p->unk06 * D_800BE9E4;
+    p->unk05 += p->unk07 * D_800BE9E4;
+    arg0->unk38 = (func_151423D8(p->unk04 - 0x40) * p->unk08) + p->unk00;
+    arg0->unk3C = (func_151423D8(p->unk05 - 0x40) * p->unk0C) + p->unk00;
+    return 1;
+}
+
+// func_151D9534: dispatcher (physics update + 3 render-call branches). The reconstruction below is
+// algorithmically EXACT and the else-branch is byte-identical modulo a float-register cascade.
+// Best hand score 2175. PERMUTER CANDIDATE: in the (unkC1&2) physics block the target keeps
+// D_800AB44C's VALUE live in $f2 and reuses it for the unk58 and unk60 multiplies, but IDO here
+// address-CSEs it (materializes &D_800AB44C in v0, hoisted above the branch) and reloads the value,
+// adding 2 insns whose $f-register renaming cascades through the whole else branch. The forced
+// store order (unk58, unk44, unk5C, unk60) defeats value-CSE by hand; needs the permuter.
+//
+// extern f32 D_800AB44C, D_800AB450, D_800AB454, D_800AB458, D_800AB45C, D_800AB460;
+// s32 func_1514672C(f32 *arg0);
+// s32 func_15046C80(f32 *arg0, s32 arg1, f32 arg2, f32 *arg3);
+// void func_151DAB58(u8, f32, u8, void*, s32, u8, s32);
+// SubA8_9534 { f32 unk10@0x10; f32 unk14@0x14; u8 unk18@0x18; }
+// Struct9534Arg1 { f32 unk04@0x04; }
+// Struct9534 { u8 unk01; u8 unk0C; u8 unk2B; f32 unk38,unk3C,unk40,unk44,unk48; f32 unk58,unk5C,
+//              unk60,unk64; s32 unk68; f32 unk80; u8 unk84,unk9D,unkA8,unkC1; }
+// s32 func_151D9534(Struct9534 *arg0, Struct9534Arg1 *arg1) {
+//     u8 ret; f32 sp50[3]; SubA8_9534 *p; f32 val;   // decl order sets -g3 debug slots
+//     ret = 1;
+//     if (arg0->unk44 < arg1->unk04) {
+//         sp50[0] = arg0->unk40; sp50[1] = arg1->unk04; sp50[2] = arg0->unk48;
+//         if (func_1514672C(sp50) == 0) return 0;
+//         if (func_15046C80(sp50, 0, arg0->unk44, &arg0->unk80) != 0) {
+//             sp50[1] = arg0->unk80 + 2.0f;
+//             if (arg0->unkC1 & 2) {
+//                 arg0->unk58 = arg0->unk58 * D_800AB44C;
+//                 arg0->unk44 = (arg0->unk3C * D_800AB450) + sp50[1];
+//                 arg0->unk5C = arg0->unk5C * D_800AB454;
+//                 arg0->unk60 = arg0->unk60 * D_800AB44C;
+//                 if (fabsf(arg0->unk5C) < D_800AB458) {
+//                     arg0->unk58 = 0.0f; arg0->unk68 &= ~6;
+//                     arg0->unk5C = 0.0f; arg0->unk60 = 0.0f; arg0->unk64 = 0.0f;
+//                 }
+//             } else {
+//                 ret = 0; p = (SubA8_9534 *) &arg0->unkA8;
+//                 val = (arg0->unk38 + arg0->unk3C) * 0.5f;
+//                 if (arg0->unk9D == 3)
+//                     func_151D9FC0(p->unk18, p->unk14 * val, arg0->unk2B, (s32)&arg0->unk84, (s32)sp50, arg0->unk0C, arg0->unk01);
+//                 else if (func_150ADA20() & 1)
+//                     func_151D9B8C(p->unk18, (val * D_800AB45C) * p->unk10, arg0->unk2B, (s32)&arg0->unk84, (struct17*)sp50, 0x64, 0, 1, 0, arg0->unk0C, arg0->unk01);
+//                 else
+//                     func_151DAB58(p->unk18, (val * D_800AB460) * p->unk10, arg0->unk2B, sp50, 1, arg0->unk0C, arg0->unk01);
+//             }
+//         }
+//     }
+//     return ret;
+// }
 #pragma GLOBAL_ASM("asm/nonmatchings/game_2062D0/func_151D9534.s")
 
 u8 func_151D97A8(void) {
@@ -167,7 +281,37 @@ u8 func_151D9B34(void) {
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_2062D0/func_151D9B8C.s")
 
-#pragma GLOBAL_ASM("asm/nonmatchings/game_2062D0/func_151D9EB0.s")
+typedef struct {
+    /* 0x00 */ s16 unk00;
+    /* 0x02 */ char pad02[0x2];
+    /* 0x04 */ f32 unk04;
+    /* 0x08 */ f32 unk08;
+    /* 0x0C */ char pad0C[0x8];
+    /* 0x14 */ u8 unk14;
+    /* 0x15 */ u8 unk15;
+    /* 0x16 */ u8 unk16;
+    /* 0x17 */ char pad17[1];
+} Sub9EB0;
+
+typedef struct {
+    /* 0x00 */ char pad00[0x1];
+    /* 0x01 */ u8 unk01;
+    /* 0x02 */ char pad02[0xC - 0x2];
+    /* 0x0C */ u8 unk0C;
+    /* 0x0D */ char pad0D[0x28 - 0xD];
+    /* 0x28 */ s16 unk28;
+    /* 0x2A */ char pad2A[0x40 - 0x2A];
+} Struct9EB0;
+
+void func_151D9EB0(Struct9EB0 *arg0) {
+    Sub9EB0 *p;
+    arg0->unk28 -= D_800BE9E4;
+    if (arg0->unk28 < 0) {
+        p = (Sub9EB0 *) &arg0->unk28;
+        func_151D9014(&p->unk08, &D_800A5480, p->unk16, (func_150ADA68() * D_800AB464) + D_800AB468, (func_150ADA20() % 0x29U) + 0x23, p->unk14, p->unk04, 0, 1.0f, 1.0f, p->unk15, 0, 1, 0, arg0->unk0C, arg0->unk01);
+        p->unk00 = (func_150ADA20() % 0x6FU) + 0x1E;
+    }
+}
 
 void func_151D9FC0(u8 arg0, f32 arg1, u8 arg2, s32 arg3, s32 arg4, u8 arg5, s32 arg6) {
     func_151DBCBC(arg0, arg1 * 0.5f, arg2, arg3, arg4, arg5, arg6);
@@ -178,13 +322,128 @@ void func_151D9FC0(u8 arg0, f32 arg1, u8 arg2, s32 arg3, s32 arg4, u8 arg5, s32 
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_2062D0/func_151DA08C.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_2062D0/func_151DA368.s")
+
+s32 func_151DA6A8(Struct2062D0 *arg0) {
+    Struct2062D0Sub *sp;
+    s32 i;
+
+    if (arg0->unk058 & 1) {
+        sp = &arg0->unk128;
+        i = D_800BE9E4;
+        while (i--) {
+            sp->unk010 *= sp->unk014;
+        }
+    }
+    return 1;
+}
+
 // TODO when we know what arg0 is...
-#pragma GLOBAL_ASM("asm/nonmatchings/game_2062D0/func_151DA6A8.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_2062D0/func_151DA6F8.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_2062D0/func_151DA938.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_2062D0/func_151DAA88.s")
+
+void func_151DAB58(u8 arg0, f32 arg1, u8 arg2, void *arg3, s32 arg4, u8 arg5, s32 arg6);
+
+typedef struct {
+    /* 0x00 */ f32 unk00;
+    /* 0x04 */ char pad04[0x4];
+    /* 0x08 */ u8 unk08;
+} SubUnk98A938;
+
+typedef struct {
+    /* 0x00 */ f32 unk00;
+    /* 0x04 */ char pad04[0x1B - 0x4];
+    /* 0x1B */ u8 unk1B;
+    /* 0x1C */ char pad1C[0x20 - 0x1C];
+    /* 0x20 */ u8 unk20;
+    /* 0x21 */ char pad21[0x48 - 0x21];
+    /* 0x48 */ f32 unk48;
+    /* 0x4C */ char pad4C[0x50 - 0x4C];
+    /* 0x50 */ u8 unk50;
+    /* 0x51 */ char pad51[0x3];
+} StructA938Unk98;
+
+typedef struct {
+    /* 0x00 */ f32 unk00;
+    /* 0x04 */ char pad04[0x4];
+    /* 0x08 */ f32 unk08;
+    /* 0x0C */ char pad0C[0x8];
+} StructAA88Elem;
+
+typedef struct {
+    /* 0x00 */ f32 unk00;
+    /* 0x04 */ char pad04[0x17];
+    /* 0x1B */ u8 unk1B;
+    /* 0x1C */ char pad1C[0x20 - 0x1C];
+    /* 0x20 */ u8 unk20;
+    /* 0x21 */ char pad21[0x4C - 0x21];
+    /* 0x4C */ f32 unk4C;
+    /* 0x50 */ u8 unk50;
+    /* 0x51 */ char pad51[0x3];
+} StructAA88Unk98;
+
+typedef struct {
+    /* 0x00 */ char pad00[0x1];
+    /* 0x01 */ u8 unk01;
+    /* 0x02 */ char pad02[0xA];
+    /* 0x0C */ u8 unk0C;
+    /* 0x0D */ char pad0D[0x2D - 0x0D];
+    /* 0x2D */ s8 unk2D;
+    /* 0x2E */ char pad2E[0x94 - 0x2E];
+    /* 0x94 */ StructAA88Elem *unk94;
+    /* 0x98 */ StructAA88Unk98 *unk98;
+} StructAA88;
+
+s32 func_151DA938(StructAA88 *arg0, s32 arg1, s32 arg2, s32 arg3, f32 arg4, s32 arg5) {
+    StructAA88Elem *e;
+    StructA938Unk98 *p98;
+    f32 vec[3];
+    SubUnk98A938 *q;
+
+    e = arg0->unk94;
+    p98 = (StructA938Unk98 *) arg0->unk98;
+    vec[0] = e[arg0->unk2D].unk00;
+    vec[1] = arg4 + 2.0f;
+    vec[2] = e[arg0->unk2D].unk08;
+    q = (SubUnk98A938 *) &p98->unk48;
+    if (func_150ADA20() & 1) {
+        func_151D9B8C(q->unk08, (p98->unk00 * 3.0f) * q->unk00, p98->unk1B, arg5, (struct17 *) vec, 0x64, 0, 1, 0, arg0->unk0C, arg0->unk01);
+    } else {
+        func_151DAB58(q->unk08, (p98->unk00 * D_800AB49C) * q->unk00, p98->unk1B, vec, 1, arg0->unk0C, arg0->unk01);
+    }
+    p98->unk20 = 4;
+    return 1;
+}
+
+s32 func_151DAA88(StructAA88 *arg0, s32 arg1, s32 arg2, s32 arg3, f32 arg4, s32 arg5) {
+    StructAA88Unk98 *p98;
+    StructAA88Elem *e;
+    f32 sp[3];
+
+    e = arg0->unk94;
+    p98 = arg0->unk98;
+    sp[0] = e[arg0->unk2D].unk00;
+    sp[1] = arg4;
+    sp[2] = e[arg0->unk2D].unk08;
+    func_151D9FC0(p98->unk50, (p98->unk00 * 11.0f) * p98->unk4C, p98->unk1B, arg5, (s32) sp, arg0->unk0C, arg0->unk01);
+    p98->unk20 = 4;
+    return 1;
+}
 #pragma GLOBAL_ASM("asm/nonmatchings/game_2062D0/func_151DAB58.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_2062D0/func_151DADA0.s")
+
+s32 func_151DADA0(Struct2062D0 *arg0) {
+    Struct2062D0Sub110 *p;
+    f32 temp;
+
+    p = &arg0->unk110;
+    p->unk00 += p->unk01 * D_800BE9E4;
+    temp = func_151423D8(p->unk00 - 0x40);
+    arg0->unk04C = (p->unk04 * temp) + 1.0f;
+    arg0->unk050 = D_800AB4B0 - (p->unk08 * temp);
+    return 1;
+}
+
+// func_151DAE28: quad-transform (func_151D5D60 + memcpy + vertex math). Vertex math
+// reconstructed but a header-context frame quirk (separate return-value save at 0x48,
+// frame 8 bytes short) + branch polarity resist a byte-match. Best hand score ~4888.
 #pragma GLOBAL_ASM("asm/nonmatchings/game_2062D0/func_151DAE28.s")
 
 void func_151DB004(struct218 *arg0) {
@@ -292,8 +551,58 @@ void func_151DB4CC(struct218 *arg0) {
 }
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_2062D0/func_151DB5D0.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_2062D0/func_151DB97C.s")
+typedef struct {
+    /* 0x00 */ u8 unk00;
+    /* 0x01 */ char pad01[0x3];
+    /* 0x04 */ s32 unk04;
+    /* 0x08 */ u8 unk08;
+    /* 0x09 */ u8 unk09;
+    /* 0x0A */ u8 unk0A;
+    /* 0x0B */ u8 unk0B;
+    /* 0x0C */ u8 unk0C;
+    /* 0x0D */ u8 unk0D;
+    /* 0x0E */ char pad0E[0x2];
+    /* 0x10 */ f32 unk10;
+    /* 0x14 */ f32 unk14;
+    /* 0x18 */ f32 unk18;
+} SubB97C;
 
+typedef struct {
+    /* 0x00 */ char pad00[0x4C];
+    /* 0x4C */ f32 unk4C;
+    /* 0x50 */ f32 unk50;
+    /* 0x54 */ f32 unk54;
+    /* 0x58 */ s32 unk58;
+    /* 0x5C */ char pad5C[0xA8 - 0x5C];
+    /* 0xA8 */ SubB97C unkA8;
+} StructB97C;
+
+s32 func_151DB97C(StructB97C *arg0, s32 arg1) {
+    SubB97C *s0;
+    f32 r3;
+    f32 r2;
+    f32 r1;
+
+    s0 = &arg0->unkA8;
+    if (s0->unk00 & 2) {
+        func_15131918(&arg0->unk58, s0->unk04);
+    }
+    if (s0->unk00 & 1) {
+        s0->unk08 += s0->unk0B * D_800BE9E4;
+        s0->unk09 += s0->unk0C * D_800BE9E4;
+        s0->unk0A += s0->unk0D * D_800BE9E4;
+        r1 = func_151423D8(s0->unk08 - 0x40);
+        r2 = func_151423D8(s0->unk09 - 0x40);
+        r3 = func_151423D8(s0->unk0A - 0x40);
+        arg0->unk4C = s0->unk10 * r1;
+        arg0->unk50 = s0->unk14 * r2;
+        arg0->unk54 = s0->unk18 * r3;
+    }
+    return 1;
+}
+
+// Struct-builder for func_15153F18; heavy IDO scheduling (early &tmp.unk8 pointer
+// reuse as store base + exact store ordering) resists a byte-match. Best hand score 3503.
 #pragma GLOBAL_ASM("asm/nonmatchings/game_2062D0/func_151DBAA8.s")
 
 // typedef struct {
@@ -385,6 +694,36 @@ void func_151DBBD4(struct17 *arg0, s32 arg1, u8 *arg2, u8 arg3, s32 arg4) {
     func_151D9B8C(tmp2.unkF, (tmp2.unk0 * 25.0f) + 10.0f, ((tmp2.unk4 % 0x38U) + 200), arg1 + 4, &tmp, (func_150ADA20() % 0x97U) + 150, 0, 1, 0, arg3, arg4);
 }
 
+// func_151DBCBC: stack-struct builder that fills a 0x28-byte descriptor at sp+0x50 and
+// dispatches to func_1513C73C (arg3!=0) or func_1513C5B0 (arg3==0). The reconstruction below
+// is algorithmically EXACT (all ops byte-identical) but the struct-init constant materialization
+// is scheduled with a different temp-register reuse pattern than the target, whose renames
+// cascade through the whole function. Hand-reordering the assignments only makes it worse
+// (3557 vs 3070). NON-MATCHING: best 3070. PERMUTER CANDIDATE.
+//
+// extern u8 D_800AB414[];
+// typedef struct {
+//     s32 unk00; s16 unk04; s8 unk06; s8 unk07; s32 unk08; s32 unk0C;
+//     u8 unk10,unk11,unk12,unk13,unk14,unk15,unk16,unk17; s32 unk18; s32 unk1C;
+//     u8 unk20; char pad21[1]; s16 unk22; s16 unk24;
+// } StructBCBC;
+// void func_151DBCBC(u8 arg0, f32 arg1, s16 arg2, s32 arg3, void *arg4, u8 arg5, s32 arg6) {
+//     StructBCBC sp50; struct17 *v = (struct17 *) arg4; u8 *tbl; s32 c1, c2, c3;
+//     tbl = &D_800AB414[arg0 * 3];
+//     sp50.unk00 = 0x67B02; sp50.unk04 = 0x12C; sp50.unk06 = 0x38; sp50.unk07 = 0;
+//     sp50.unk08 = 0; sp50.unk0C = 0x8000; sp50.unk10 = arg2; sp50.unk11 = 0xFF;
+//     sp50.unk12 = tbl[0]; sp50.unk13 = tbl[1]; sp50.unk14 = tbl[2]; sp50.unk15 = 0xFF;
+//     sp50.unk16 = 0; sp50.unk17 = 6; sp50.unk18 = 0x440001; sp50.unk1C = 0;
+//     sp50.unk20 = 0xFF; sp50.unk22 = 1; sp50.unk24 = 0xFF;
+//     if (arg3 != 0) {
+//         c1 = func_150ADA20(); c2 = func_150ADA20(); c3 = func_150ADA20();
+//         func_1513C73C((s32)&sp50, 0, 0, arg3, v->unk0, v->unk4, v->unk8, arg1, arg1, c1,
+//                       ((c3 & 1) << 1) + (c2 & 1), 0, arg5, arg6);
+//     } else {
+//         func_1513C5B0((s32)&sp50, 0, 0, 0, v->unk0, v->unk4, v->unk8, arg1, arg1,
+//                       0, 0, 0, arg5, arg6);
+//     }
+// }
 #pragma GLOBAL_ASM("asm/nonmatchings/game_2062D0/func_151DBCBC.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_2062D0/func_151DBE80.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_2062D0/func_151DC034.s")

--- a/conker/src/game_221290.c
+++ b/conker/src/game_221290.c
@@ -3,42 +3,135 @@
 #include "functions.h"
 #include "variables.h"
 
+typedef s32 (*Callback221290)(s32, void *, s32, s32);
 
+typedef struct {
+    /* 0x0000 */ s32 unk0;
+    /* 0x0004 */ Callback221290 unk4;
+    /* 0x0008 */ s32 unk8;
+    /* 0x000C */ s32 unkC;
+    /* 0x0010 */ s32 unk10;
+    /* 0x0014 */ s32 unk14;
+    /* 0x0018 */ s32 unk18;
+    /* 0x001C */ u8  unk1C[0x2000];
+    /* 0x201C */ s32 unk201C;
+    /* 0x2020 */ s32 unk2020;
+    /* 0x2024 */ char pad2024[0x3BA0 - 0x2024];
+    /* 0x3BA0 */ s32 unk3BA0;
+    /* 0x3BA4 */ char pad3BA4[0x3F88 - 0x3BA4];
+    /* 0x3F88 */ s32 unk3F88;
+    /* 0x3F8C */ char pad3F8C[0x6A64 - 0x3F8C];
+    /* 0x6A64 */ u8  unk6A64[0x900];
+    /* 0x7364 */ char pad7364[0x8474 - 0x7364];
+    /* 0x8474 */ s32 unk8474;
+    /* 0x8478 */ s32 (*unk8478)(void *);
+} Struct221290;
+
+extern Struct221290 D_800E1880;
+extern s32 func_151F8088(void *, s32);
+extern void (*D_800E0E00)(s32, void *, s32);
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_221290/func_151F3DE0.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_221290/func_151F42E8.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_221290/func_151F4F38.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_221290/func_151F578C.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_221290/func_151F63C4.s")
+// NON-MATCHING: best 2213. Algorithm reconstructed but -g codegen shape differs:
+// target reserves 8 bytes at frame bottom (frame 0x18 vs 0x10) and hoists the loop
+// counter increment into the guard's delay slot for the counter-unused copy loops.
+// s32 func_151F6970(Struct221290 *p, s32 idx) {
+//     s16 *base16 = D_800AEB7C[*(s32 *)((u8 *)p + 0x3BA4)][*(s32 *)((u8 *)p + 0x3BB4)];
+//     f32 *dst = (f32 *)((u8 *)p + 0x4F64);
+//     f32 *src = (f32 *)((u8 *)p + 0x4664);
+//     s32 i = 0;
+//     if (*(s32 *)((u8 *)p + idx * 4 + 0x3C98) != 0 && *(s32 *)((u8 *)p + idx * 4 + 0x3CA0) == 2) {
+//         if (*(s32 *)((u8 *)p + idx * 4 + 0x3CA8) != 0) {
+//             for (; i < 0x24; i++) { *dst++ = *src++; }
+//         }
+//         for (; i < 0x240; i++) { dst[base16[i]] = *src++; }
+//     } else {
+//         for (; i < 0x240; i++) { *dst++ = *src++; }
+//     }
+//     return 1;
+// }
 #pragma GLOBAL_ASM("asm/nonmatchings/game_221290/func_151F6970.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_221290/func_151F6B28.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_221290/func_151F6FD0.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_221290/func_151F78B4.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_221290/func_151F7F60.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_221290/func_151F8088.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_221290/func_151F85C4.s")
-// void *func_151F85C4(s32 arg0, s32 arg1, s32 arg2) {
-//     void *sp1C;
-//
-//     sp1C = (void *)0x800E1880;
-//     if (sp1C == 0) {
-//         return NULL;
-//     }
-//     sp1C->unkC = -1;
-//     sp1C->unk10 = -1;
-//     sp1C->unk14 = -1;
-//     sp1C->unk0 = arg0;
-//     sp1C->unk4 = arg1;
-//     sp1C->unk8 = arg2;
-//     sp1C->unk201C = 0;
-//     sp1C->unk2020 = 0;
-//     sp1C->unk3BA0 = 0;
-//     if (func_151F8088(sp1C, 0) == 0) {
-//         return NULL;
-//     }
-//     sp1C->unk8474 = 0;
-//     bzero(sp1C + 0x6A64, 0x900);
-//     return sp1C;
-// }
+s32 func_151F7F60(Struct221290 *arg0) {
+    s32 n = 0x1000;
+    s32 result;
 
-#pragma GLOBAL_ASM("asm/nonmatchings/game_221290/func_151F86B0.s")
+    if ((arg0->unk201C + arg0->unk3F88) >= 0x1FFC) {
+        bcopy(&arg0->unk1C[n], &arg0->unk1C[0], n);
+        arg0->unk201C -= n;
+        arg0->unk2020 -= n << 3;
+    }
+    result = arg0->unk4(arg0->unk0, &arg0->unk1C[arg0->unk201C], arg0->unk3F88, -1);
+    if (result < arg0->unk3F88) {
+        bzero(&arg0->unk1C[result], arg0->unk3F88 - result);
+    }
+    arg0->unk18 += arg0->unk3F88;
+    arg0->unk201C += arg0->unk3F88;
+    return arg0->unk201C - arg0->unk3F88;
+}
+#pragma GLOBAL_ASM("asm/nonmatchings/game_221290/func_151F8088.s")
+Struct221290 *func_151F85C4(s32 arg0, Callback221290 arg1, s32 arg2) {
+    Struct221290 *temp = &D_800E1880;
+
+    if (temp == NULL) {
+        return NULL;
+    }
+    temp->unkC = -1;
+    temp->unk10 = -1;
+    temp->unk14 = -1;
+    temp->unk0 = arg0;
+    temp->unk4 = arg1;
+    temp->unk8 = arg2;
+    temp->unk201C = 0;
+    temp->unk2020 = 0;
+    temp->unk3BA0 = 0;
+    if (func_151F8088(temp, 0) == 0) {
+        return NULL;
+    }
+    temp->unk8474 = 0;
+    bzero(temp->unk6A64, 0x900);
+    return temp;
+}
+
+s32 func_151F86B0(void *arg0, void **arg1, s32 *arg2) {
+    Struct221290 *temp;
+    s32 result2;
+    u8 buf[0x100];
+    s32 j;
+
+    temp = arg0;
+    temp->unk3BA0++;
+    if (temp->unk3BA0 >= 6) {
+        temp->unk3BA0 = 0;
+    }
+    if (func_151F8088(temp, temp->unk8474) == 0) {
+        D_800E0E04 = 3;
+        return 0;
+    }
+    temp->unk8474 = -1;
+    result2 = temp->unk8478(temp);
+    if (result2 == 0) {
+        goto end;
+    }
+    *arg1 = (u8 *)temp + temp->unk3BA0 * 1160 + 0x2070;
+    *arg2 = *(s32 *)((u8 *)temp + 0x3F8C);
+    if (*(s32 *)((u8 *)temp + 0x3BC8) != 0) {
+        j = 0;
+        do {
+            if (temp->unk4(temp->unk0, &buf[j], 1, -1) == 0) {
+                break;
+            }
+        } while (buf[j++]);
+        if (D_800E0E00 != NULL) {
+            D_800E0E00(0, buf, strlen(buf) + 1);
+        }
+    }
+end:
+    return result2;
+}

--- a/conker/src/game_2DF70.c
+++ b/conker/src/game_2DF70.c
@@ -5,6 +5,14 @@
 
 #include "macros.h"
 
+s32 func_150027F8(s8 *arg0);
+void func_15002560(s8 *arg0, s8 *arg1);
+void func_15002008(s32 arg0, s32 arg1, s32 arg2, s32 arg3, s32 arg4);
+s32 func_15002248(s32 arg0, s32 arg1, s32 arg2, s32 arg3, s32 *arg4, s32 *arg5, s32 arg6, s32 *arg7);
+
+typedef struct { s16 x, z; } Coord_l;
+extern Coord_l *D_800DBE44;
+
 void func_15000AC0(void) {
     D_800D9E64 = (u8)0;
 }
@@ -30,31 +38,33 @@ void func_15001970(void) {
     D_800B0DC4 = D_800B0DC0;
 }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/game_2DF70/func_15001A08.s")
-// NON-MATCHING: JUSTREG
+// NON-MATCHING: best 445 (permuter candidate). Structure/frame (0x28) correct; residual is
+// a temp-register allocation cascade (target uses v0 for the 3 PI-status reads, IDO picks t8),
+// the D_A0000000 %hi/%lo reloc on the ROM read (literal 0xA0000000 gives no reloc), and a
+// trailing D_15001B08 `jr ra;nop` stub. size is spilled to 0x24(sp) across both PI calls.
+// permuter NO ZERO, best 345 (was 445): permuter only lever was retyping D_800B0DDC to
+// `volatile unsigned int` (445->345), which can't be applied without editing the header.
+// Even a perfect register match cannot reach 0: the ROM read needs a %hi/%lo reloc against
+// the named symbol D_A0000000 (literal 0xA0000000 emits reloc-free lui/ori), and the compared
+// region includes a separate trailing stub `glabel D_15001B08 (jr ra; nop)` that no single
+// C body for this func can emit. Both need symbol/split config (off-limits). Reverted to pragma.
 // void func_15001A08(void) {
-//     s32 sp24;
-//     s32 tmp;
-//     s32 sp1C;
+//     s32 size;
+//     u8 *ret;
+//     u32 romval;
 //
-//     tmp = D_800BE9F0;
-//     sp24 = D_80091AF0[tmp];
-//
-//     __osPiGetAccess();
-//
-//     while ((IO_READ(PI_STATUS_REG) & 3)) {};
-//
-//     tmp = D_80000308 | 0xB0000D24 | 0xA0000000;
-//     sp1C = *(s32*)tmp;
-//
-//     __osPiRelAccess();
-//
-//     if (sp1C != 0x98CCE31A) {
-//         sp24 <<= 1;
+//     size = D_80091AF0[D_800BE9F0];
+//     __osPiGetAccess(size);
+//     while (*(vu32 *)0xA4600010 & 3) {
 //     }
-//
-//     D_800B0DDC = allocate_memory(sp24, 1, 0, 0);
-//     D_800B0DE0 = D_800B0DDC;
+//     romval = *(u32 *)((D_80000308 | 0xB0000D24) | 0xA0000000);
+//     __osPiRelAccess(size);
+//     if (romval != 0x98CCE31A) {
+//         size <<= 1;
+//     }
+//     ret = allocate_memory(size, 1, 0, 0);
+//     D_800B0DDC = (s32) ret;
+//     D_800B0DE0 = ret;
 //     D_800B0DCC = 0;
 //     D_800B0DD0 = 0;
 //     D_800DBE30 = 0;
@@ -62,6 +72,7 @@ void func_15001970(void) {
 //     D_800DBE34 = 0;
 //     D_800DBE36 = 0;
 // }
+#pragma GLOBAL_ASM("asm/nonmatchings/game_2DF70/func_15001A08.s")
 
 u16* func_15001B10(void) {
     u16 *temp_v0;
@@ -206,10 +217,95 @@ u16 *func_15001DE0(s32 arg0, s32 arg1, s32 arg2, s32 arg3, s32 arg4, s32 arg5) {
     return temp_v0;
 }
 
+typedef struct { f32 x, y, z; } Vec3f_l;
+typedef struct { Vec3f_l v[3]; } Tri9_l;
+typedef struct { s16 x, y, z; } DbVtx_l;
+typedef struct { DbVtx_l *v[3]; } DbTri_l;
+
+s32 func_15049260(Tri9_l arg0);
+
 // 3 loops
+// NON-MATCHING: algorithmically complete (best 6715). Residual is a pervasive saved-register
+// allocation + stack-layout cascade: target puts arg1/arg0/arg3/arg2 in s0/s1/s2/s3 and hoists
+// the 0x80000001 vertex-validity threshold to s4 and &tri.v[3] to s5, while IDO here assigns the
+// args to s2-s5 and the invariants to s0/s1, and the tri temp lands at sp+0x70 vs sp+0x78. Needs
+// a permuter register-swap pass (or manual saved-register coercion) from this base.
+// void func_15002008(s32 arg0, s32 arg1, s32 arg2, s32 arg3, s32 arg4) {
+//     Tri9_l tri;
+//     u16 *list, *end, *p;
+//     s32 count, s6, prev;
+//     DbTri_l *dt;
+//     func_150492CC((f32)(arg1 - arg0), 32000.0f, (f32)(arg3 - arg2));
+//     prev = -1;
+//     list = (u16 *)arg4;
+//     count = list[0];
+//     if (count > 0) {
+//         end = &list[count + 1];
+//         p = &list[1];
+//         s6 = *p;
+//         do {
+//             Vec3f_l *out; DbVtx_l **vp; s32 r;
+//             dt = (DbTri_l *)D_800DBE3C + s6;
+//             out = tri.v;
+//             vp = dt->v;
+//             do {
+//                 DbVtx_l *vtx = *vp;
+//                 if ((u32)vtx < 0x80000001U) {
+//                     out->x = 0.0f; out->y = 0.0f; out->z = 0.0f;
+//                 } else {
+//                     out->x = (f32)(vtx->x - (arg0 + arg1) / 2);
+//                     out->y = (f32)vtx->y;
+//                     out->z = (f32)(vtx->z - (arg2 + arg3) / 2);
+//                 }
+//                 out++; vp++;
+//             } while (out != &tri.v[3]);
+//             r = func_15049260(tri);
+//             if (r == 0) {
+//                 if (prev == -1) { func_15001B8C(s6 | 0x8000); prev = s6; }
+//                 else if ((s6 - prev) < 0x80) { func_15001B5C(s6 - prev); prev = s6; }
+//                 else { func_15001B8C(s6 | 0x8000); prev = s6; }
+//             }
+//             p++;
+//         } while (p != end);
+//     }
+//     func_15001B5C(0);
+// }
 #pragma GLOBAL_ASM("asm/nonmatchings/game_2DF70/func_15002008.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_2DF70/func_15002248.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_2DF70/func_15002560.s")
+
+void func_15002560(s8 *arg0, s8 *arg1) {
+    s8 *s1;
+    s32 v0;
+
+loop:
+    if (arg0 == 0) {
+        return;
+    }
+    if (*(s16 *)(arg0 + 4) == 0) {
+        if (arg1 != 0) {
+            v0 = (s32)arg1 - (s32)arg0;
+        } else {
+            v0 = 0;
+        }
+        *(s16 *)(arg0 + 4) = v0;
+    }
+    v0 = *(s16 *)(arg0 + 0xC);
+    if (v0 == 0) {
+        return;
+    }
+    s1 = arg0 + v0;
+    if (*(s16 *)(s1 + 4) != 0) {
+        s8 *s0;
+        do {
+            s0 = s1;
+            s0 += *(s16 *)(s1 + 4);
+            func_15002560(s1, s0);
+            s1 = s0;
+        } while (*(s16 *)(s0 + 4) != 0);
+    }
+    arg0 = s1;
+    goto loop;
+}
 
 void func_150025FC(void) {
     s32 tmp0;
@@ -246,10 +342,47 @@ void func_15002724(s32 arg0) {
     D_800DBE38 += func_150027F8(arg0);
 }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/game_2DF70/func_15002754.s")
+void func_15002754(void) {
+    s32 idx;
+
+    D_800B0DC0 = ALIGN4(D_800B0DC0);
+    idx = D_800DBE50;
+    D_800DBDD8[idx] = D_800B0DC0;
+    D_800B0DC0 += D_800DBE38 * 12;
+    D_800DBDE8[idx] = D_800B0DC0;
+    D_800B0DC0 += D_800DBE38 * 8;
+    D_800DBDF8[idx] = D_800B0DC0;
+    D_800B0DC0 += D_800DBE38 * 4;
+    func_1510F800(idx);
+    D_800DBE38 = 0;
+}
 
 
-#pragma GLOBAL_ASM("asm/nonmatchings/game_2DF70/func_150027F8.s")
+s32 func_150027F8(s8 *arg0) {
+    s32 count;
+    s32 total;
+    s8 val;
+
+    if (arg0 == 0) {
+        return 0;
+    }
+
+    count = 0;
+    total = 0;
+    val = arg0[0];
+    while (val != -0x21) {
+        count++;
+        if ((val >> 4) == 1) {
+            total += 4;
+        } else if (val == 6) {
+            total += 2;
+        } else if (val == 5) {
+            total += 1;
+        }
+        val = *(s8 *)((count << 3) + (s32)arg0);
+    }
+    return total;
+}
 
 s32 func_15002878(void) {
     s32 i;

--- a/conker/src/game_305D0.c
+++ b/conker/src/game_305D0.c
@@ -4,9 +4,109 @@
 #include "variables.h"
 
 
-// what is this loop doing?
-#pragma GLOBAL_ASM("asm/nonmatchings/game_305D0/func_15003120.s")
+typedef struct {
+    s32 f0;
+    s32 f4;
+    s32 f8;
+} Node305D0;
 
+#define P32_305D0 (*(s32 **)D_800B0E30)
+#define P8_305D0  (*(u8 **)D_800B0E34)
+
+// PERMUTER CANDIDATE (JUSTREG, best 140): byte-identical except target inserts
+// `move a3,a1` up front (keeps arg1 in a3, allocates a1 to the reloaded node pointer);
+// mine keeps arg1 in a1, node ptr in a3. arg1 and the pointer necessarily interfere;
+// pure graph-coloring coin-flip, not source-controllable by hand.
+void func_15003120(s32 arg0, s32 arg1, s32 arg2) {
+    s32 i;
+    s32 new_var;
+    P32_305D0[arg0] = arg2;
+    P8_305D0[arg0] = 0;
+    if (arg2 == 0) return;
+    P32_305D0[arg0] += arg1;
+    i = 0;
+    new_var = P32_305D0[arg0];
+    if (((Node305D0 *) new_var)->f0 != 0) {
+        do {
+            ((Node305D0 *) P32_305D0[arg0])[i].f0 += arg1;
+            ((Node305D0 *) P32_305D0[arg0])[i].f4 += arg1;
+            i++;
+        } while (((Node305D0 *) P32_305D0[arg0])[i].f0 != 0);
+    }
+    P8_305D0[arg0] = i;
+}
+
+// NON-MATCHING (best 7146): reconstruction below is ALGORITHMICALLY COMPLETE and the
+// body/main-loop matches instruction-for-instruction (verified: beqzl/bnel branch-likely,
+// pointer relocations with obj+tmp operand order, the D_800B0E00/E10/E20/E40[i] block, the
+// second D_80082B20 walk all align). The ONLY blocker is the 3-element zeroing loop over
+// D_800B0E04/E14/E44 (terminating at &D_800B0E50). In isolation IDO compiles this loop
+// byte-perfect (same registers v1=E44,a0=E04,a1=E14,end=D_800B0E44+0xC as the target), but
+// in the full function IDO's global regalloc keeps &D_800B0E50 in a saved reg (shared with
+// the `D_800B0E50 = ret` store), reuses it as the loop end, computes the runtime pointer
+// distance (subu) and applies Duff's-device unrolling -> total cascade. Tried: pointer
+// do-while / while, for-counter (shared & dedicated index), sized [3] vs incomplete arrays,
+// store reorder, volatile store -- ALL unroll in-context. To match, the target needs
+// D_800B0E44 and D_800B0E50 to be compile-time-adjacent (one struct/array) so IDO knows the
+// trip is 3 while still emitting the D_800B0E50 symbol; that requires a header/symbol-layout
+// change (forbidden here), not a source mutation. NOT a permuter candidate (declaration issue).
+//
+// extern s32 func_1502B6BC(s32 *arg0, s32 arg1, s32 *arg2, s32 count, ...);
+// extern void *allocate_memory(s32 size, s32 arg1, s32 arg2, s32 arg3);
+// extern void func_150049A4(s32 arg0, s32 arg1, s32 arg2);
+// extern void func_1510CE60(s32 arg0, s32 arg1, s32 arg2, s32 arg3, s32 arg4);
+// extern u32 func_1510D0EC(s32 arg0, s32 arg1, s32 arg2, s32 arg3);
+// extern void func_15003120(s32 arg0, s32 arg1, s32 arg2);
+// extern s32 D_800B0E14[3]; extern s32 D_800B0E44[3]; extern s32 D_800B0E50;
+// extern s32 D_800B0E10[]; extern s32 D_800B0E20[]; extern s32 D_800B0E40[]; extern u8 D_800B0E38;
+// typedef struct { s32 unk0,unk4,unk8,unkC,unk10; u8 pad14[0xC]; s32 unk20,unk24; u8 unk28[4]; } Obj305;
+// typedef struct { Obj305 *unk0; s32 unk4; } Ent305;
+// void func_150031EC(s32 arg0) {
+//     s32 sp50[4]; s32 sp60; s32 sp64; Ent305 *ent; Obj305 *obj; s32 i, ret, tmp; void *p;
+//     if (arg0 >= 0x45) arg0 = 0;
+//     ret = func_1502B6BC(&sp60, 0, &sp64, 2, 4, arg0);
+//     D_800B0E50 = ret;
+//     { s32 k; for (k = 0; k < 3; k++) { (&D_800B0E04)[k] = 0; D_800B0E14[k] = 0; D_800B0E44[k] = 0; } }
+//     func_150034B4();
+//     if (sp60 == 0) goto second;
+//     D_800B0E30[0] = (s32) allocate_memory(sp64 * 4, 1, 0, 0);
+//     p = allocate_memory(sp64, 1, 0, 0); D_800B0E34[0] = (s32) p;
+//     bzero(p, sp64); bzero((void *) D_800B0E30[0], sp64);
+//     tmp = sp64; i = 0; D_800B0E38 = (u8) tmp; if (tmp == 0) goto second;
+//     ent = (Ent305 *) ret; obj = ent->unk0;
+//     do {
+//         if (obj != 0 && ent->unk4 != 0) {
+//             tmp = obj->unk0;  if (tmp != 0) obj->unk0 = (s32) obj + tmp;
+//             tmp = obj->unk8;  if (tmp != 0) obj->unk8 = (s32) obj + tmp;
+//             tmp = obj->unk10; if (tmp != 0) obj->unk10 = (s32) obj + tmp;
+//             func_15003120(i, (s32) obj, obj->unk20);
+//             if ((u32) i < 4U) {
+//                 s32 u0 = obj->unk0;
+//                 D_800B0E10[i] = (s32) obj + 0x28;
+//                 D_800B0E40[i] = (u32) (u0 - (s32) obj - 0x28) >> 4;
+//                 D_800B0E00[i] = u0;
+//                 D_800B0E20[i] = obj->unk8;
+//                 if (i == 0) func_150039BC(obj->unk10);
+//                 func_150049A4(D_800B0E00[i], D_800B0E10[i] + 0xFF000000, (s32) obj);
+//                 func_1510CE60(D_800B0E00[i], 0, 1, 0x3F, 0);
+//             } else {
+//                 func_150049A4(obj->unk0, 0, (s32) obj);
+//             }
+//         }
+//         i++; ent++; obj = ent->unk0;
+//     } while ((u32) i < (u32) sp64);
+// second:
+//     { s32 idx, *base, node, off;
+//       idx = ((u8 *) D_800B0DF0)[0x4B];
+//       if (idx != 0) {
+//           base = (s32 *) (&D_80082B20)[idx]; off = 4; node = base[0];
+//           if (node != 0) do {
+//               func_1510D0EC(node, (s32) sp50, 0x3E, 0);
+//               base = (s32 *) (&D_80082B20)[((u8 *) D_800B0DF0)[0x4B]];
+//               node = *(s32 *) ((s32) base + off); off += 4;
+//           } while (node != 0);
+//       } }
+// }
 #pragma GLOBAL_ASM("asm/nonmatchings/game_305D0/func_150031EC.s")
 
 s32 func_150034B4(void) {
@@ -27,39 +127,34 @@ s32 func_150034B4(void) {
       }
 }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/game_305D0/func_15003570.s")
-// NON-MATCHING: something along these lines
+// PERMUTER CANDIDATE (best 210, the plain-[i] form below). Logic exact & verified. Header
+// bugs handled: D_800B87A0 written via `sh` (s32[] -> s16, stride 2); D_80091D20 read via `lhu`
+// (s32[] -> u16, stride 2); D_1A37E0 is a symbol (ROM addr). Remaining diff is a coupled
+// terminator/register choice: the write-first [i] form (below) gets correct registers
+// (s2=read, s3=write) and store scheduling (post-inc store at -2) but strength-reduces the loop
+// on the READ pointer (end D_80091D20+0x3ca4) -- base-symbol mismatch vs target's write end
+// (D_800B87A0+0x3ca4, shown by splat as D_800BC444). Putting the write last flips termination to
+// the write pointer (base symbol then MATCHES at object level) but swaps s2/s3 -> 985. A
+// do-while pointer-walk gets the write terminator but regresses `*w++` store scheduling
+// (store-at-0 vs -2) -> 950/1185. IDO couples "which pointer terminates" to "which gets s2",
+// so write=s3 + write-terminates + [i]-style store isn't hand-reachable. Permuter territory.
+// permuter NO ZERO, best 210 (permuter reached 105 normalized only by reusing s1 to hold the
+// packed word -> semantic change to `s0 += D_80091D20[i] + s1`, not adoptable; no true zero).
+// extern u8 D_1A37E0[]; extern void *allocate_memory(s32,s32,s32,s32); extern void func_10004074(void*);
 // void func_15003570(void) {
-//     s32 temp_s4;
-//     s32 phi_s0;
-//     s32 phi_s1;
-//
-//     s32 i;
-//     u8 *temp_v0;
-//     s16 *phi_s2;
-//     s16 *phi_s3;
-//
-//     temp_s4 = allocate_memory(16, 1, 2, 0);
-//
-//     phi_s0 = 0x1A37E0; // 1718240
-//     phi_s2 = D_80091D20;
-//     phi_s3 = D_800B87A0;
-//
+//     u8 *buf; s32 s0, s1, i; u8 *v0;
+//     buf = allocate_memory(0x10, 1, 2, 0);
+//     s0 = (s32) D_1A37E0;
 //     for (i = 0; i < 7762; i++) {
-//         if ((phi_s0 & 1) != 0) {
-//             phi_s0 = phi_s0 - 1;
-//             phi_s1 = 1;
-//         } else {
-//             phi_s1 = 0;
-//         }
-//         func_10004514(phi_s0, temp_s4, 16, 1);
-//         temp_v0 = temp_s4 + phi_s1;
-//         phi_s2[i] = (*temp_v0 << 24) + (*(temp_v0 + 1) << 16) + (*(temp_v0 + 2) << 8) + *(temp_v0 + 3);
-//         phi_s0 = phi_s3[i];
+//         if (s0 & 1) { s0 -= 1; s1 = 1; } else { s1 = 0; }
+//         func_10004514(s0, buf, 0x10, 1);
+//         v0 = s1 + buf;
+//         ((s16 *) D_800B87A0)[i] = (v0[0]<<24) + (v0[1]<<16) + (v0[2]<<8) + v0[3];
+//         s0 += ((u16 *) D_80091D20)[i] + s1;
 //     }
-//
-//     func_10004074(temp_s4);
+//     func_10004074(buf);
 // }
+#pragma GLOBAL_ASM("asm/nonmatchings/game_305D0/func_15003570.s")
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_305D0/func_15003668.s")
 // NON-MATCHING: 40% there

--- a/conker/src/game_30E90.c
+++ b/conker/src/game_30E90.c
@@ -19,16 +19,139 @@ void func_150045BC(void) {
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_30E90/func_150045C4.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_30E90/func_150049A4.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_30E90/func_15004A4C.s")
-// NON-MATCHING: not this...
-// void func_15004A4C(void) {
-//     u32 i;
-//     for (i = 0; i < D_800DBEF0; i++) {
-//         D_800DBEFC[i] = D_800DBEF8[i] = 0;
-//         // D_800DBEFC[i] = 0;
+
+// NON-MATCHING (best score 510). Display-list relocation walking 8-byte commands.
+// Every instruction of the loop matches; the only real diff is the preheader: the
+// target loads the command byte a second time after the guard branch
+// (lb a2, 0(a0)) whereas IDO CSEs our second read into "move a1,a3". That single
+// difference also flips which of arg1/arg2 is spilled to s0. Attempts to defeat
+// the CSE (distinct struct type at the same offset, raw s8 cast, array vs pointer
+// syntax, do-while vs while) all still CSE.
+//
+// typedef struct { s8 b0; s8 b1; s8 b2; u8 b3; u32 w1; } GfxCmd;
+//
+// void func_150049A4(GfxCmd *gfx, u32 arg1, u32 arg2) {
+//     s32 i = 0;
+//     GfxCmd *p = gfx;
+//     s32 c;
+//
+//     if (gfx->b0 != -0x21) {
+//         c = gfx->b0;
+//         do {
+//             i++;
+//             switch (c) {
+//                 case 0xDE:
+//                     p->w1 += arg1;
+//                     break;
+//                 case 1:
+//                     p->w1 += arg1;
+//                     break;
+//                 case -0x24:
+//                     if (p->b3 == 0xE) {
+//                         p->w1 += arg2;
+//                     }
+//                     break;
+//             }
+//             p = &gfx[i];
+//             c = p->b0;
+//         } while (p->b0 != -0x21);
 //     }
 // }
 
+void func_15004A4C(void) {
+    s32 i;
+
+    for (i = 0; i < D_800DBEF0; i++) {
+        (*(s32 **)&D_800DBEF8)[i] = 0;
+        (*(u8 **)&D_800DBEFC)[i] = 0;
+    }
+}
+
 #pragma GLOBAL_ASM("asm/nonmatchings/game_30E90/func_15004AAC.s")
+// NON-MATCHING. Body computation is VERIFIED byte-exact (per-vertex load/cvt/mul/add/trunc
+// and the whole post-loop sqrt + BE2A0/2/4 branch chain match opcode-for-opcode; confirmed
+// via the register-diff-only middle section). The ONLY blocker is IDO uopt's "searchloop"
+// reduction unroller: the natural `for (i=0;i<count;i++)` max-reduction loop below gets
+// 2x-unrolled with odd-iteration peeling and saved FP regs (score ~9977) whereas the target
+// is NOT unrolled. uopt exposes NO -Wo flag to disable this (checked: -OPT:*, -Wo,-*unroll*
+// are ignored/unrecognized; LOOP_UNROLL in the Makefile is referenced-but-undefined). The
+// byte-offset variant `for (off=0; off<count*16; off+=16)` DEFEATS the unroller and reaches
+// best 425, but then IDO guards on count*16 (blez count<<4) instead of count (blez count),
+// and the residual is FP+int register rotation. Likely a permuter/source-structure puzzle.
+//
+// (byte-offset near-miss form, best 425:)
+// typedef struct { s16 unk0; s16 unk2; s16 unk4; u8 pad6[0xA]; } AacVtx;              // 0x10
+// typedef struct { u8 pad0[0x16]; u16 unk16; u8 pad18[0x10]; AacVtx *unk28;
+//                  f32 unk2C; f32 unk30; f32 unk34; u8 pad38[0x18]; u16 unk50; u16 unk52; } AacObj; // 0x54
+// extern u16 D_800BE2A0, D_800BE2A2, D_800BE2A4;
+// void func_15004AAC(AacObj *arg0, s32 arg1) {           // arg1 homed-but-unused (sw a1,4(sp))
+//     s32 max = 0, count = arg0->unk16, off, r;
+//     for (off = 0; off < count * 16; off += 16) {
+//         AacVtx *p = (AacVtx*)((u8*)arg0->unk28 + off);
+//         f32 fz = p->unk4 * arg0->unk34;
+//         f32 fx = p->unk0 * arg0->unk2C;
+//         f32 fy = p->unk2 * arg0->unk30;
+//         s32 val = (s32)(fz * fz + (fx * fx + fy * fy));
+//         if (max < val) max = val;
+//     }
+//     if (max == 0) return;
+//     r = (s32)sqrtf((f32)max);
+//     if (arg0->unk50 == 0) { arg0->unk50 = r; arg0->unk52 = r; D_800BE2A2++; }
+//     else if ((arg0->unk50 < r) || (arg0->unk52 < r)) D_800BE2A0++;
+//     else D_800BE2A4++;
+// }
+
 #pragma GLOBAL_ASM("asm/nonmatchings/game_30E90/func_15004BF0.s")
+// NON-MATCHING (best 1465). PERMUTER CANDIDATE — algorithmically exact: every opcode
+// matches 1:1 and in order. Sole diff is a whole-function register rotation: the target
+// keeps loop-invariants start/count in the arg regs a0/a1 (start coalesced into the
+// incoming a0) and loop-variants i/id in v0/v1; IDO gives our build the reverse
+// (start/count -> v0/v1, i/id -> a0/a1) no matter how the source is ordered — even
+// literally reusing the arg0 variable as `start` did not make IDO keep it in a0. Plus a
+// single commutative `addu base,offset` vs `offset,base`. Pure register permutation.
+//
+// s32 func_15004BF0(s32 arg0) {
+//     s32 count, i, id;
+//     if (arg0 == 0) {                       // forward scan: lowest free id from D_800DBF00
+//         count = D_800DBEF0;
+//         arg0  = D_800DBF00;                 // start
+//         id = 1;
+//         if (arg0 < count) {
+//             i = arg0;
+//             do {
+//                 if (((u8*)((u8*)D_800DBEF4 + i * 0xA0))[0x72] == id) { id++; i = arg0 - 1; }
+//                 i++;
+//                 if (id >= 0x100) return 0xFF;
+//             } while (i < count);
+//         }
+//         return id;
+//     } else {                               // backward scan: highest free id from 0xFF-D_800DBF00
+//         arg0  = 0xFF - D_800DBF00;          // base
+//         count = D_800DBEF0;
+//         id = arg0;
+//         if (count > 0) {
+//             i = 0;
+//             do {
+//                 if (id == ((u8*)((u8*)D_800DBEF4 + i * 0xA0))[0x72]) { id--; i = -1; }
+//                 i++;
+//                 if (id <= 0) return arg0;
+//             } while (i < count);
+//         }
+//         return id;
+//     }
+// }
 #pragma GLOBAL_ASM("asm/nonmatchings/game_30E90/func_15004CE0.s")
+// NON-MATCHING (best 215, register-only + 1 structural). Body is instruction-identical.
+// Target emits TWO separate `lb 0(a0)` in the preheader (loop-rotation re-reads b0 for
+// the guard AND the carried value); IDO CSEs our two reads into one `lb`+`move`. The
+// pre-check+do-while form is WORSE (310, adds move a1,a2). PERMUTER CANDIDATE — the
+// residual is all register renames once the second load lands.
+//   typedef struct { s8 b0; s8 b1; s8 b2; u8 b3; u32 w1; } GfxCmd;
+//   void func_15004CE0(GfxCmd *gfx, u32 arg1) {
+//       s32 i = 0; GfxCmd *p = gfx; s32 c = gfx->b0;
+//       while (c != -0x21) {
+//           i++;
+//           if ((c == -0x24) && (p->b3 == 0xE) && (p->w1 < 0x80000000)) p->w1 += arg1;
+//           p = &gfx[i]; c = p->b0;
+//       }
+//   }

--- a/conker/src/game_35D20.c
+++ b/conker/src/game_35D20.c
@@ -3,5 +3,49 @@
 #include "variables.h"
 
 // loops and loops
-#pragma GLOBAL_ASM("asm/nonmatchings/game_35D20/func_15008870.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_35D20/func_15008930.s")
+
+extern s32 D_800DCE50[2][104];
+extern void (*D_80082BD0[])(void);
+extern void (*D_80082BD4[])(void);
+extern s32 D_800DD1B0;
+
+void func_15008870(s32 arg0) {
+    s32 start = 0;
+    s32 end = 0x68;
+    s32 i;
+    s32 j;
+
+    if (arg0 == 1) {
+        end = 0x65;
+    } else if (arg0 == 2) {
+        start = 0x65;
+    }
+
+    for (j = 0; j < 2; j++) {
+        for (i = start; i < end; i++) {
+            D_800DCE50[j][i] = 0;
+        }
+    }
+}
+
+void func_15008930(s32 arg0) {
+    void (**funcs)(void);
+    s32 count;
+    s32 i;
+
+    if (arg0 == 1) {
+        funcs = D_80082BD0;
+        count = 1;
+    } else if (arg0 == 2) {
+        funcs = D_80082BD4;
+        count = 1;
+    } else {
+        count = 0;
+    }
+
+    for (i = 0; i < count; i++) {
+        funcs[i]();
+    }
+
+    D_800DD1B0 = -1;
+}

--- a/conker/src/game_362B0.c
+++ b/conker/src/game_362B0.c
@@ -3,8 +3,34 @@
 #include "variables.h"
 
 
+extern u8 D_800DDE54[];
+extern f32 *D_800DDE60[];
+
+typedef struct {
+    u8  pad0[0x14];
+    s16 unk14;
+    u8  pad16;
+    u8  unk17;
+} Struct8008D050;
+
+extern Struct8008D050 D_8008D050[];
+
 void func_15008E00(void) {
     D_800DDE50 = (u8)0;
 }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/game_362B0/func_15008E10.s")
+void func_15008E10(s32 arg0) {
+    s32 i;
+
+    D_800DDE54[D_800DDE50] = arg0;
+    D_800DDE60[D_800DDE50] = (f32 *) allocate_memory(0x1E0, 1, 0, 0);
+
+    for (i = 0; i < 120; i += 3) {
+        D_800DDE60[D_800DDE50][i] = 0.0f;
+        D_800DDE60[D_800DDE50][i + 2] = D_800DDE60[D_800DDE50][i + 1] = D_800DDE60[D_800DDE50][i];
+    }
+
+    D_800DDE60[D_800DDE50][0x77] = (f32) D_8008D050[arg0].unk14;
+    D_8008D050[arg0].unk17 = 0;
+    D_800DDE50++;
+}

--- a/conker/src/game_3D9A0.c
+++ b/conker/src/game_3D9A0.c
@@ -2,9 +2,15 @@
 #include "functions.h"
 #include "variables.h"
 
+extern u8 D_800D9950[3];
 
-// ???
-#pragma GLOBAL_ASM("asm/nonmatchings/game_3D9A0/func_150104F0.s")
+struct26 *func_151149AC(u32);
+
+void func_150104F0(void) {
+    D_800D9950[0] = D_800D9950[1] = D_800D9950[2] = 0;
+    func_151149AC(0xF6)->unk7C = 2.0f;
+    D_80088980 = 0;
+}
 
 void func_15010538(struct127 *arg0) {
     struct175 tmp;
@@ -26,11 +32,33 @@ dummy_label_927029:
 }
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_3D9A0/func_15010600.s")
-// NON-MATCHING: addresses are wrong :(
+// NON-MATCHING: best score 70. The whole unrolled loop body, all six scalar
+// stores and their order, and every register assignment match exactly; only
+// two instructions differ, and both are artifacts of splat having split what
+// was originally a single pair of 14-byte arrays into seven separate symbols:
+//   1. the loop limit is emitted as reloc D_800D993A+0xc, but the expected
+//      object (assembled from the .s) has reloc D_800D9946+0. These resolve to
+//      the same linked address, but the addend changes the addiu's raw bytes.
+//      Getting a zero addend requires the array base to be D_800D9946 itself,
+//      which then breaks the loop base (tried: score 95).
+//   2. "sb zero,%lo(D_800D9939)(at)" schedules before the three loop-setup
+//      addiu's instead of after them. In the original this store is the second
+//      peeled iteration of a 14-trip loop (14 = 2 + 3*4), emitted after the
+//      induction-variable init; it cannot be reproduced from standalone scalar
+//      stores, and a real peel would reintroduce non-zero addends.
+// A true match needs D_800D9928/9929/992A and D_800D9938/9939/993A/9946 merged
+// into two u8[14] arrays in variables.h + undefined_syms, which is out of scope.
+//
 // void func_15010600(void) {
 //     s32 i;
 //
-//     for (i = 0; i < 11; i++) {
-//         D_800D9930[i] = D_800D9920[i] = 0;
+//     D_800D9921 = 0;
+//     D_800D9920 = 0;
+//     D_800D9928 = 0;
+//     D_800D9938 = 0;
+//     D_800D9929 = 0;
+//     D_800D9939 = 0;
+//     for (i = 0; i < 12; i++) {
+//         D_800D993A[i] = D_800D992A[i] = 0;
 //     }
 // }

--- a/conker/src/game_40490.c
+++ b/conker/src/game_40490.c
@@ -11,6 +11,50 @@ void func_15012FE0(void) {
 }
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_40490/func_15013000.s")
+// NON-MATCHING: best score 275. The whole loop body is byte-identical; only the
+// prologue schedule differs - IDO hoists the `lw D_800D3094` above the two global
+// stores and sinks the `swc1 D_800DCD90` into the branch delay slot, while the
+// target keeps source order and fills the delay slot from the loop preheader.
+// Tried: for/while/do-while + explicit guard, explicit offset vs array indexing,
+// swapped store order, stores through cast pointers - none change the hoist.
+// (The `off + (s32)base` form is also needed to keep the two `addu`s from being
+// CSE'd; with plain pointer arithmetic IDO merges them.)
+//
+// // structs.h types D_800D3098 as an array of struct178; it is really a pointer
+// // to an array of 0x34-byte entries.
+// typedef struct {
+//     u8 pad0[0x15];
+//     u8 unk15;
+//     u8 pad16[0x1E];
+// } Struct40490Elem; // size 0x34
+//
+// extern void (*D_80082E30[])(Struct40490Elem *);
+//
+// void func_15013000(void) {
+//     u32 i;
+//     s32 off;
+//     u8 *base;
+//     s32 x;
+//     void (*func)(Struct40490Elem *);
+//
+//     D_800DCDC4 = 0;
+//     D_800DCD90 = 0.0f;
+//     i = 0;
+//     off = 0;
+//     if (D_800D3094 == 0) {
+//         return;
+//     }
+//     do {
+//         base = *(u8 **) &D_800D3098;
+//         x = ((Struct40490Elem *) (base + off))->unk15;
+//         func = D_80082E30[(u8) (x >> 2)];
+//         if (func != NULL) {
+//             func((Struct40490Elem *) (off + (s32) base));
+//         }
+//         i++;
+//         off += 0x34;
+//     } while (i < D_800D3094);
+// }
 // requires jump table
 #pragma GLOBAL_ASM("asm/nonmatchings/game_40490/func_150130B4.s")
 
@@ -30,7 +74,61 @@ s32 func_1501374C(struct16 *arg0) {
     return 1;
 }
 
-// fat struct definition:
+// NON-MATCHING: best score 1283. The entire function body is byte-identical (every
+// value, call, and store matches) EXCEPT a uniform +4 stack-offset shift on the
+// mtx+tmp aggregate block: the target packs recip(0x4C)+mtx(0x50)+tmp(0x90) into one
+// 8-aligned contiguous block, while IDO here gives the named `f32 recip` an 8-byte
+// spill slot (0x4C-0x53), pushing mtx to 0x54 and tmp to 0x94. Tried: swapping/merging
+// mtx & tmp into one struct, recip as first struct member, recip inline-CSE, and every
+// scalar-declaration order - none reproduce the tight recip/mtx packing. There is also
+// a ~6-instruction prologue reschedule (IDO sinks `mtc1 zero,$f12` early and the
+// a0/a3 setup late). PERMUTER CANDIDATE - same stack-slot class as func_150144B8 /
+// func_150142EC. Full reconstruction below.
+//
+// extern f32 D_80096640;
+// extern f32 D_80096644;
+// extern void func_150A7960(f32 mtx[4][4], f32 arg1, f32 arg2, f32 arg3, f32 *arg4, f32 *arg5, f32 *arg6);
+//
+// typedef struct {
+//     f32 unk0, unk4, unk8, unkC, unk10, unk14, unk18, unk1C, unk20, unk24, unk28, unk2C, unk30;
+// } StructG40490; // size 0x34
+//
+// s32 func_15013778(struct134 *arg0) {
+//     StructG40490 tmp;
+//     f32 mtx[4][4];
+//     struct37 *temp_v0;
+//     f32 recip;
+//     s32 t = ((s16 *) arg0)[4];
+//
+//     if (t != 0) {
+//         tmp.unk18 = (f32) t + (f32) t;
+//         recip = 1.0f / tmp.unk18;
+//         tmp.unk1C = (f32) ((s16 *) arg0)[3];
+//         tmp.unk20 = *(f32 *) &arg0->unkC;
+//         tmp.unk28 = 0.0f;
+//         tmp.unk2C = D_80096640;
+//         tmp.unk30 = D_80096644;
+//         tmp.unk24 = *(f32 *) &arg0->unk10;
+//         tmp.unk0 = (f32) ((s16 *) arg0)[0];
+//         tmp.unk4 = (f32) ((s16 *) arg0)[1];
+//         tmp.unk8 = (f32) ((s16 *) arg0)[2];
+//         func_150A8050(mtx, *(f32 *) &arg0->unkC, *(f32 *) &arg0->unk10, 0.0f);
+//         func_150A7960(mtx, 0.0f, tmp.unk18, 0.0f, &tmp.unkC, &tmp.unk10, &tmp.unk14);
+//         tmp.unkC *= recip;
+//         tmp.unk10 *= recip;
+//         tmp.unk14 *= recip;
+//         temp_v0 = func_15149130(0x12C, -1, 0x19, -1, 0, 0x17, 0x34, 0xFF, 0);
+//         if (temp_v0 != NULL) {
+//             memcpy(&temp_v0->unk28, &tmp, 0x34);
+//         }
+//         {
+//             s32 u8b = ((s16 *) arg0)[4];
+//             func_1000FA64(0x67C, ((s16 *) arg0)[0], ((s16 *) arg0)[1] + u8b, ((s16 *) arg0)[2],
+//                           0x2EE0, u8b * 2, u8b / 2, (s32) func_1000EF40, NULL, 0, 8, 0);
+//         }
+//     }
+//     return 1;
+// }
 #pragma GLOBAL_ASM("asm/nonmatchings/game_40490/func_15013778.s")
 
 s32 func_1501396C(struct16 *arg0) {
@@ -43,40 +141,161 @@ s32 func_1501396C(struct16 *arg0) {
     return 1;
 }
 
-// another struct
-#pragma GLOBAL_ASM("asm/nonmatchings/game_40490/func_150139AC.s")
-
-#pragma GLOBAL_ASM("asm/nonmatchings/game_40490/func_15013C38.s")
-
-#pragma GLOBAL_ASM("asm/nonmatchings/game_40490/func_15013D38.s")
-// #NON-MATCHING: looks close but think its wrong
-// s32 func_151BE850(struct17 *arg0, s32 arg1, u8 arg2, u8 arg3, u8 arg4, u8 arg5, u8 arg6);
-// s32 func_15013D38(struct47 *arg0) {
-//     s32 tmp1;
-//     s32 tmp2;
-//     s32 tmp3;
-//     s32 tmp4;
-//     struct17 *tmp;
+// NON-MATCHING: best score 18. The reconstruction below is BYTE-IDENTICAL to the
+// target for every one of the 163 instructions EXCEPT the frame size: IDO here emits
+// 0xC8 (prologue `addiu sp,-0xc8` / epilogue `addiu sp,0xc8`) while the target uses
+// 0xC0. The 8 extra bytes are a dead home-slot IDO reserves for the register-resident
+// `idx` (arg0->unk18, loaded early into a1 in the prologue gap, kept until the table
+// index at the end, never spilled). The original avoids the slot via a scheduler hoist
+// of the load that I cannot reproduce from C: declaring `idx` early gives the correct
+// early load but reserves the home (score 18); inlining `&D_80095FA0[arg0->unk18]` or
+// declaring idx late removes the slot but the load then schedules late (score 400-7000).
+// Everything else - the case-2/case-0-1 body order (needs case 2 FIRST in source), the
+// commutative operand orders (unk6*unkA -> [5]*[3], unk2+unk8 -> [4]+[1]), and CRUCIALLY
+// the local declaration order (idx, e, tmp with tmp LAST so tmp lands at sp+0x50) - is
+// dialed in. PERMUTER CANDIDATE: pure stack-slot elimination, same class the sibling
+// notes (func_150144B8) say the permuter closes. Full reconstruction:
+//
+// permuter NO ZERO, best 18 (frame-size-only diff is normalized away by the
+// permuter scorer -> base score 0, cannot be guided; pscore confirms real 18)
+// extern f32 D_80096648;
+// extern f32 D_8009664C;
+//
+// typedef struct {
+//     f32 unk0; f32 unk4; f32 unk8; f32 unkC; f32 unk10;
+//     s16 unk14; s16 unk16;
+//     f32 unk18; f32 unk1C; f32 unk20; f32 unk24; f32 unk28; f32 unk2C;
+//     u8  unk30; u8 unk31; u8 unk32; u8 unk33; u8 unk34; u8 pad35[0x3];
+// } Struct40490Tbl; // size 0x38
+// extern Struct40490Tbl D_80095FA0[];
+//
+// typedef struct {
+//     struct134 *unk0;
+//     f32 unk4; f32 unk8; f32 unkC; f32 unk10; f32 unk14; f32 unk18; f32 unk1C; f32 unk20;
+//     s16 unk24; s16 unk26;
+//     f32 unk28; f32 unk2C; f32 unk30; f32 unk34; f32 unk38; f32 unk3C;
+//     u8  unk40; u8 unk41; u8 unk42; u8 pad43;
+//     s16 unk44; u8 pad46[0x2];
+//     f32 unk48; u8 pad4C[0x14];
+//     s32 unk60; u8 unk64; u8 unk65; u8 pad66[0x2]; s32 unk68; s32 unk6C;
+// } Struct40490H; // size 0x70
+//
+// s32 func_150139AC(struct134 *arg0) {
+//     s32 idx = arg0->unk18;
+//     Struct40490Tbl *e;
+//     Struct40490H tmp;
 //
 //     arg0->unk16 |= 4;
-//
-//     tmp->unk0 = arg0->unk0;
-//     tmp->unk4 = arg0->unk2;
-//     tmp->unk8 = arg0->unk4;
-//
-//     tmp4 = 1;
-//     tmp1 = arg0->unk18;
-//     if (tmp1) {
-//         tmp4 = tmp1;
+//     tmp.unk0 = arg0;
+//     tmp.unkC = 0.0f;
+//     switch (((u8 *) arg0)[0x15] & 3) {
+//     case 2:
+//         tmp.unk4 = (f32) (((s16 *) arg0)[5] * ((s16 *) arg0)[3]) * 4.0f;
+//         tmp.unk10 = (f32) (((s16 *) arg0)[4] + ((s16 *) arg0)[1]);
+//         break;
+//     case 0:
+//     case 1:
+//         tmp.unk4 = (f32) (((s16 *) arg0)[3] * ((s16 *) arg0)[3]) * D_80096648;
+//         tmp.unk10 = (f32) (((s16 *) arg0)[4] + ((s16 *) arg0)[1]);
+//         break;
+//     default:
+//         tmp.unk4 = 1.0f;
+//         tmp.unk10 = 1000.0f;
+//         break;
 //     }
-//
-//     tmp2 = arg0->unk10;
-//     tmp3 = arg0->unk1F;
-//
-//     func_151BE850(tmp, tmp2, tmp4, tmp3, 0xff, 1, 1);
+//     e = &D_80095FA0[idx];
+//     tmp.unk14 = e->unk4;
+//     tmp.unk18 = e->unk8;
+//     tmp.unk1C = e->unkC;
+//     tmp.unk20 = e->unk10;
+//     tmp.unk28 = e->unk18;
+//     tmp.unk2C = e->unk1C;
+//     tmp.unk60 = 0;
+//     tmp.unk64 = 0;
+//     tmp.unk65 = 0;
+//     tmp.unk68 = 0;
+//     tmp.unk24 = e->unk14;
+//     tmp.unk26 = e->unk16;
+//     tmp.unk30 = e->unk20;
+//     tmp.unk34 = e->unk24;
+//     tmp.unk38 = e->unk28;
+//     tmp.unk3C = e->unk2C;
+//     tmp.unk8 = e->unk0;
+//     tmp.unk40 = e->unk30;
+//     tmp.unk41 = e->unk31;
+//     tmp.unk42 = e->unk32;
+//     tmp.unk48 = D_8009664C;
+//     if (e->unk34 != 0) {
+//         func_1510F800(0);
+//         tmp.unk6C = func_1510FD20(arg0->unk0, arg0->unk4);
+//     } else {
+//         tmp.unk6C = 0;
+//     }
+//     if (e->unk33 != 0) {
+//         tmp.unk44 = func_1000FA64(0x4D, ((s16 *) arg0)[0], ((s16 *) arg0)[1], ((s16 *) arg0)[2],
+//                                   0x5DC0, 0x3E8, 0x12C, 0, 0, 0, 0, 0);
+//     } else {
+//         tmp.unk44 = 0;
+//     }
+//     {
+//         struct37 *temp_v0 = func_151491F4(0x12C, -1, 6, 0, 0xA, 0x70, 0xFF, 0);
+//         if (temp_v0 != NULL) {
+//             memcpy(&temp_v0->unk28, &tmp, 0x70);
+//         }
+//     }
 //     return 1;
 // }
+#pragma GLOBAL_ASM("asm/nonmatchings/game_40490/func_150139AC.s")
 
+extern u8 D_800C35E8;
+extern f32 D_80096650;
+extern void (*D_80082F28[])(struct134 *, f32);
+
+s32 func_15013C38(struct134 *arg0) {
+    s32 v1 = arg0->unk18;
+    void (*func)(struct134 *, f32);
+
+    arg0->unk16 |= 4;
+    if ((((u8 *) D_800D2E4C)[0x11] & 4) && (D_800BE9F0 == 0x13)) {
+        return 1;
+    }
+    if (D_800C35EA == 1) {
+        if ((D_800C35E8 == 0xF) || (D_800C35E8 == 0x10) || (D_800C35E8 == 0x11)) {
+            return 1;
+        }
+    }
+    if (v1 >= 6) {
+        return 1;
+    }
+    func = D_80082F28[v1];
+    if (func != NULL) {
+        f32 farg = (f32) (u32) arg0->unk1C * D_80096650;
+        func(arg0, farg);
+    }
+    return 1;
+}
+
+s32 func_15013D38(struct47 *arg0) {
+    struct17 tmp;
+    s32 temp_v0;
+
+    arg0->unk16 |= 4;
+    tmp.unk0 = arg0->unk0;
+    tmp.unk4 = arg0->unk2;
+    tmp.unk8 = arg0->unk4;
+
+    temp_v0 = arg0->unk18;
+    func_151BE850(&tmp, arg0->unk10, (u8) ((temp_v0 != 0) ? temp_v0 : 1), arg0->unk1F, 1, 0xFF, 1);
+    return 1;
+}
+
+// NON-MATCHING: best score 40. Byte-identical except the two adjacent halfword
+// stores tmp.unk20=0x6231 (sh @0x50) and tmp.unk22=0x1A4D (sh @0x52): IDO emits
+// the li's in the same order (t0=0x6231, t1=0x1A4D) but stores 0x52 before 0x50
+// (LIFO) while our build stores 0x50 first (FIFO) - a pure scheduler tie-break
+// not controllable from C source order (swapping the assignments flips the li
+// order and scores worse; the permuter plateaued at ~20). Full reconstruction is
+// preserved in scratchpad nonmatchings/func_15013DE8/base.c.
 #pragma GLOBAL_ASM("asm/nonmatchings/game_40490/func_15013DE8.s")
 
 s32 func_15013F9C(s32 arg0) {
@@ -122,37 +341,166 @@ s32 func_1501407C(s32 arg0) {
     return 1;
 }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/game_40490/func_15014094.s")
-// NON-MATCHING: kinda right idea, but not executed correctly
-// void func_15014094(struct134 *arg0) {
-//     struct135 tmp;
-//
-//     tmp.unk0 = arg0;
-//     // tmp.unk4 = tmp.unk0;
-//     tmp.unk0->unk16 |= 4;
-//     // tmp.unkC = tmp.unk0;
-//     // arg0 = tmp.unk0;
-//     tmp.unk10 = func_15144598(tmp.unk4); //, tmp.unk0);
-//     tmp.unk14 = 0.0f;
-//     func_1510F800(0);
-//     tmp.unk18 = func_1510FD20(arg0->unk0, arg0->unk4, arg0);
-//     tmp.unk1C = 0;
-//     tmp.unk8 = func_15149130(0x12C, -1, 0x21, -1, 0, 0, 0x34, 0xFF, 1);
-//     if (tmp.unk8 != 0) {
-//         memcpy(tmp.unk8 + 0x28, &tmp, 0x34);
-//     }
-// }
+typedef struct {
+    struct134 *unk0;
+    f32 unk4;
+    f32 unk8;
+    s32 unkC;
+    u8 pad10[0x1C];
+    u8 unk2C;
+    u8 pad2D[0x7];
+} StructB40490; // size 0x34
 
-#pragma GLOBAL_ASM("asm/nonmatchings/game_40490/func_15014144.s")
+// Declared s32 with no return statement on purpose: that is what the original
+// compiled from (no `li v0, 1` in the epilogue, but the alloc result lands in v1).
+s32 func_15014094(struct134 *arg0) {
+    StructB40490 tmp;
+    struct37 *temp_v0;
 
-#pragma GLOBAL_ASM("asm/nonmatchings/game_40490/func_15014220.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_40490/func_150142AC.s")
+    arg0->unk16 |= 4;
+    tmp.unk0 = arg0;
+    tmp.unk4 = func_15144598(arg0);
+    tmp.unk8 = 0.0f;
+    func_1510F800(0);
+    tmp.unkC = func_1510FD20(arg0->unk0, arg0->unk4);
+    tmp.unk2C = 0;
+    temp_v0 = func_15149130(0x12C, -1, 0x21, -1, 0, 0, 0x34, 0xFF, 1);
+    if (temp_v0 != NULL) {
+        memcpy(&temp_v0->unk28, &tmp, 0x34);
+    }
+}
 
-#pragma GLOBAL_ASM("asm/nonmatchings/game_40490/func_150142EC.s")
+extern s32 func_151A9390(u8, u8, struct134 *, s32, f32, f32, s32, s32, s32);
+
+s32 func_15014144(struct134 *arg0) {
+    s32 v = arg0->unk18;
+    s32 flags = ((v & 1) ? 1 : 0)
+              | ((v & 2) ? 0 : 2)
+              | ((v & 4) ? 4 : 0)
+              | ((v & 8) ? 8 : 0)
+              | ((v & 0x10) ? 0x10 : 0);
+    func_151A9390((u8) flags, ((u8 *) arg0)[0x1F], arg0, 0, *(f32 *) &D_8009667C, 100.0f, -1, 0xFF, 1);
+    return 1;
+}
+
+typedef struct {
+    f32 unk0;
+    struct134 *unk4;
+    u8 unk8;
+} StructA40490; // size 0xC
+
+s32 func_15014220(struct134 *arg0) {
+    StructA40490 tmp;
+    struct37 *temp_v0;
+
+    arg0->unk16 |= 4;
+    tmp.unk0 = 0.0f;
+    tmp.unk4 = arg0;
+    tmp.unk8 = 1;
+    temp_v0 = func_15149130(0x12C, -1, 0x26, -1, 0, 0x24, 0xC, 0xFF, 0);
+    if (temp_v0 != NULL) {
+        memcpy(&temp_v0->unk28, &tmp, 0xC);
+    }
+    return 1;
+}
+
+s32 func_150142AC(struct110 *arg0) {
+    s32 idx = arg0->unk1B;
+
+    arg0->unk16 |= 4;
+    if ((idx < 0) || (idx >= 3)) {
+        return 1;
+    }
+    D_800D9AA0[idx] = (struct134 *) arg0;
+    return 1;
+}
+
+extern f32 D_80096680, D_80096684;
+
+typedef struct {
+    struct134 *unk0;
+    f32 unk4;
+    f32 unk8;
+    f32 unkC;
+    f32 unk10;
+    f32 unk14;
+} StructH40490; // size 0x18
+
+s32 func_150142EC(struct134 *arg0) {
+    StructH40490 tmp;
+    struct37 *temp_v0;
+    f32 a, b, c, d;
+    f32 ret;
+
+    arg0->unk16 |= 4;
+    if (D_80082FA0 >= 2) {
+        return 1;
+    }
+    if ((((u8 *) D_800D2E4C)[0x11] & 4) && (D_800BE9F0 == 0x13)) {
+        return 1;
+    }
+    a = (f32) ((u32) arg0->unk1C & 0xFFFF) * D_80096680;
+    b = (f32) (((u32) arg0->unk1C >> 16) & 0xFFFF) * D_80096680;
+    c = (f32) ((u32) arg0->unk20 & 0xFFFF) * D_80096680;
+    d = (f32) (((u32) arg0->unk20 >> 16) & 0xFFFF) * D_80096680;
+    ret = func_1514462C((s32) arg0);
+    tmp.unk0 = arg0;
+    tmp.unk4 = (a * ret) * D_80096684;
+    tmp.unk8 = (b * ret) * D_80096684;
+    tmp.unkC = c;
+    tmp.unk10 = d;
+    tmp.unk14 = 0.0f;
+    temp_v0 = func_15149130(0x12C, -1, 0x29, -1, 0, 0, 0x18, 0xFF, 0);
+    if (temp_v0 != NULL) {
+        memcpy(&temp_v0->unk28, &tmp, 0x18);
+    }
+    return 1;
+}
+// NON-MATCHING: structurally byte-perfect (every instruction matches) except a
+// uniform +8 stack-offset shift - IDO reserves an extra 8-byte scratch slot at the
+// bottom of the locals that the target does not. The permuter reaches score 0 via a
+// `*(&arg0->unk18)` pointer-reload, but only under its self-contained preamble's FP
+// allocation; that fix does not transfer to the repo's full-header context. Full
+// reconstruction preserved in scratchpad nonmatchings/func_150144B8/base.c.
 #pragma GLOBAL_ASM("asm/nonmatchings/game_40490/func_150144B8.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_40490/func_1501474C.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_40490/func_15014B60.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_40490/func_15014F6C.s")
+typedef struct {
+    struct134 *unk0;
+    u32 unk4;
+    u32 unk8;
+    u32 unkC;
+    f32 unk10[4][4];
+    u8 unk50;
+    u8 unk51;
+    u8 pad52[0x2];
+} StructF40490; // size 0x54
+
+s32 func_15014F6C(struct134 *arg0) {
+    StructF40490 tmp;
+    struct37 *temp_v0;
+    u8 r;
+    s32 v;
+
+    arg0->unk16 |= 4;
+    tmp.unk51 = arg0->unk20;
+    v = (arg0->unk1C & 1) ? 1 : 0;
+    tmp.unk50 = v;
+    tmp.unk0 = arg0;
+    tmp.unk4 = arg0->unk18 & 0xFFFF;
+    tmp.unk8 = ((u32) arg0->unk18 >> 16) & 0xFFFF;
+    r = func_150ADA20();
+    tmp.unkC = r % (tmp.unk8 + 1) + tmp.unk4;
+    func_150A8050(tmp.unk10, *(f32 *) &arg0->unkC, *(f32 *) &arg0->unk10, 0.0f);
+    tmp.unk10[3][0] = (f32) ((s16 *) arg0)[0];
+    tmp.unk10[3][1] = (f32) ((s16 *) arg0)[1];
+    tmp.unk10[3][2] = (f32) ((s16 *) arg0)[2];
+    temp_v0 = func_15149130(0x12C, -1, 0x31, -1, 0, 0x2A, 0x54, 0xFF, 0);
+    if (temp_v0 != NULL) {
+        memcpy(&temp_v0->unk28, &tmp, 0x54);
+    }
+    return 1;
+}
 
 s32 func_150150A4(void) {
     struct17 *temp_v0 = func_1515F1B0();
@@ -165,8 +513,81 @@ s32 func_150150A4(void) {
     return 1;
 }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/game_40490/func_15015104.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_40490/func_150151D4.s")
+typedef struct {
+    struct134 *unk0;
+    u8 unk4;
+    s32 unk8;
+    u8 unkC;
+    s32 unk10;
+} StructD40490; // size 0x14
+
+s32 func_15015104(struct134 *arg0) {
+    StructD40490 tmp;
+    struct37 *temp_v0;
+    s32 v;
+
+    ((u8 *) arg0)[0x14] = 1;
+    tmp.unk0 = arg0;
+    tmp.unk4 = arg0->unk1C;
+    func_1510F800(0);
+    tmp.unk8 = func_1510FD20(arg0->unk0, arg0->unk4);
+    v = arg0->unk20;
+    tmp.unkC = ((v != 0) ? 1 : 0) | ((v != 0) ? 2 : 0);
+    tmp.unk10 = 0;
+    temp_v0 = func_15149130(0x12C, -1, -1, -1, 0, 0x2C, 0x14, 0xFF, 0);
+    if (temp_v0 != NULL) {
+        memcpy(&temp_v0->unk28, &tmp, 0x14);
+    }
+    return 1;
+}
+extern f32 D_800966B4;
+
+typedef struct {
+    struct134 *unk0;
+    f32 unk4;
+    s16 unk8;
+    f32 unkC;
+    f32 unk10;
+    f32 unk14;
+    f32 unk18;
+    f32 unk1C;
+    f32 unk20;
+    u8 pad24[0x14];
+    s32 unk38;
+    u8 unk3C;
+    u8 unk3D;
+    u8 pad3E[0x2];
+    s32 unk40;
+    s32 unk44;
+} StructE40490; // size 0x48
+
+s32 func_150151D4(struct134 *arg0) {
+    StructE40490 tmp;
+    struct37 *temp_v0;
+
+    arg0->unk16 |= 4;
+    ((u8 *) arg0)[0x14] = 1;
+    tmp.unk0 = arg0;
+    tmp.unk4 = 0.0f;
+    tmp.unk8 = -1;
+    tmp.unkC = (f32) ((s16 *) arg0)[0];
+    tmp.unk10 = (f32) ((s16 *) arg0)[1];
+    tmp.unk14 = (f32) ((s16 *) arg0)[2];
+    tmp.unk18 = (f32) ((s16 *) arg0)[3];
+    tmp.unk1C = (f32) ((s16 *) arg0)[4];
+    tmp.unk20 = D_800966B4;
+    tmp.unk40 = 0;
+    tmp.unk3D = 0;
+    tmp.unk3C = 0;
+    tmp.unk38 = 0;
+    func_1510F800(0);
+    tmp.unk44 = func_1510FD20(arg0->unk0, arg0->unk4);
+    temp_v0 = func_15149130(0x12C, -1, 0x3C, -1, 0, 0x2D, 0x48, 0xFF, 0);
+    if (temp_v0 != NULL) {
+        memcpy(&temp_v0->unk28, &tmp, 0x48);
+    }
+    return 1;
+}
 
 s32 func_15015300(struct134 *arg0) {
     void (*func)(void);
@@ -186,5 +607,28 @@ s32 func_15015300(struct134 *arg0) {
 
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_40490/func_15015354.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_40490/func_15015644.s")
+typedef struct {
+    struct134 *unk0;
+    f32 unk4;
+    s32 unk8;
+    u8 unkC;
+} StructC40490; // size 0x10
+
+s32 func_15015644(struct134 *arg0) {
+    StructC40490 tmp;
+    struct37 *temp_v0;
+
+    arg0->unk16 |= 4;
+    ((u8 *) arg0)[0x14] = 1; // structs.h types struct134.unk14 as u16; this is a byte store
+    tmp.unk0 = arg0;
+    tmp.unk4 = func_15144598(arg0);
+    func_1510F800(0);
+    tmp.unk8 = func_1510FD20(arg0->unk0, arg0->unk4);
+    tmp.unkC = 0;
+    temp_v0 = func_15149130(0x12C, -1, 0x44, -1, 0, 0x2F, 0x10, 0xFF, 0);
+    if (temp_v0 != NULL) {
+        memcpy(&temp_v0->unk28, &tmp, 0x10);
+    }
+    return 1;
+}
 #pragma GLOBAL_ASM("asm/nonmatchings/game_40490/func_150156F4.s")

--- a/conker/src/game_447B0.c
+++ b/conker/src/game_447B0.c
@@ -35,8 +35,30 @@ void func_15017498(void) {
     bzero(&D_800D2138, 524);
 }
 
-// double-loop
-#pragma GLOBAL_ASM("asm/nonmatchings/game_447B0/func_150174C0.s")
+// D_800D23C0 is declared as s32 in variables.h (shared header, not editable here)
+// but is really a pointer to an array of 0x18-byte records. RECORDS reinterprets
+// the storage as the correct pointer type.
+typedef struct {
+    /* 0x00 */ s16 unk0;
+    /* 0x02 */ u16 unk2;
+    /* 0x04 */ s32 unk4;
+    /* 0x08 */ u16 unk8[8];
+} Struct150174C0; /* size = 0x18 */
+
+#define RECORDS (*(Struct150174C0**)&D_800D23C0)
+
+void func_150174C0(s32 arg0) {
+    s32 i;
+    s32 j;
+
+    for (i = 0; i < (s32)D_80087380; i++) {
+        for (j = 0; j < RECORDS[i].unk2; j++) {
+            if ((RECORDS[i].unk8[j] >> 12) == 2) {
+                RECORDS[i].unk8[j] += arg0;
+            }
+        }
+    }
+}
 
 void func_15017578(s32 arg0) {
     u32 tmp = 0;

--- a/conker/src/game_45B80.c
+++ b/conker/src/game_45B80.c
@@ -5,6 +5,25 @@
 
 
 void* func_151674F8(void *arg0, s32 arg1, s16 arg2, s32 arg3);
+s32 func_1517F4D8(s32 arg0, s32 arg1);
+s32 func_1517F3A0(s32 arg0, s32 arg1);
+s32 func_15180580(s32 arg0, s32 arg1);
+s32 func_1507DB6C(s32 arg0, s32 arg1);
+s32 func_1510FEA0(s32 arg0, s32 arg1);
+s32 func_1502BAD0(s32 arg0, s32 arg1, s16 arg2);
+extern Mtx D_80089470;
+extern u8 D_800DCD27;
+
+typedef struct {
+    s32 pad0;
+    s32 unk4;
+    s32 pad8;
+    s32 unkC;
+    s32 pad10;
+    s32 unk14;
+    s32 pad18;
+    s32 unk1C;
+} Struct45B80Ctr;
 
 
 void func_150186D0(void) {
@@ -97,6 +116,99 @@ void func_1501905C(void) {
 }
 
 // few loops
+// NON-MATCHING: best ~5895, algorithmically exact. Everything matches byte-for-byte
+// EXCEPT the final array-increment loop (loop 3), which IDO unrolls 4x here but not in
+// the target. Loops 1 & 2 (with func calls) match; loop 3 has no call so IDO unrolls it.
+// Could not defeat the unroll from clean C (struct-ptr, flat-ptr, end-in-local all unroll;
+// named temps add -g3 frame slots). Not permuter-fixable (needs the un-unrolled schedule).
+/*
+s32 func_15019130(void) {
+    s32 i;
+    u8 j;
+    s32 *p;
+    s32 *end;
+
+    func_1510D864();
+    func_1509BA04(0);
+    func_1509BBA0(2);
+    D_800DCD27 = 0;
+    func_10004250();
+    func_1501E400(0);
+    func_15034F20();
+    func_1510B690();
+    func_1510F800(0);
+    func_15113180();
+    if (D_800BEAC0 == 0) {
+        func_15113E54(1);
+    }
+    if (D_800BEAC0 == 0) {
+        func_15114188();
+    }
+    func_15044A28();
+    func_15018DFC();
+    func_150242F8(1, 0);
+    func_1501EC38(0);
+    func_150242F8(0, 0);
+    func_15020EC4(0);
+    func_1501E2F8(0);
+    if ((s8)D_800D23A9 != 0) {
+        func_15087CC0();
+    }
+    func_15122AE0();
+    func_1504ADD0();
+    func_1510F800(0);
+    for (i = 0; i <= D_80082FA0; i++) {
+        func_1510FC34(i);
+    }
+    func_1510B690();
+    for (j = 0; j <= D_80082FA0; j++) {
+        func_15094EA0(j);
+    }
+    func_15112A80(0);
+    func_151749F8(D_800BE9F0, 0);
+    func_1501C860();
+    func_1511FC20(D_800BE9C0);
+    func_15188B74(0);
+    if (D_800BEAC0 == 0) {
+        func_1516706C();
+        func_151671E8();
+    }
+    func_1502BEE4();
+    if (D_800BE616 == 0) {
+        func_150A0D8C();
+    }
+    func_15113218();
+    func_15188B74(1);
+    func_151738C4(D_800BE9F0);
+    func_1502C1A4();
+    func_15113C88();
+    if (D_800CC2B0 != 0) {
+        func_150636F0();
+    }
+    if (D_800BEAC0 == 0) {
+        func_15183D28();
+        func_151670C0();
+        func_15177A94();
+    }
+    if (D_800BEAC0 == 0) {
+        func_151814FC();
+    }
+    func_1517F75C();
+    func_1517F7B4();
+    func_15036148();
+    func_1515D6C8();
+    p = (s32 *)&D_80043B40;
+    end = (s32 *)&D_80044B20;
+    do {
+        p[1]++;
+        p[3]++;
+        p[5]++;
+        p[7]++;
+        p += 8;
+    } while (p != end);
+    return 1;
+}
+*/
 #pragma GLOBAL_ASM("asm/nonmatchings/game_45B80/func_15019130.s")
 
 void func_15019414(void) {
@@ -109,59 +221,62 @@ void func_15019414(void) {
     }
 }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/game_45B80/func_15019464.s")
-// NON-MATCHING: 70% of the way there... maybe.
-// s32 func_15019464(Gfx *arg0, s16 arg1) {
-//     s32 temp_s0;
-//     s32 ret;
-//
-//     func_1510B958(arg1);
-//     gSPViewport(arg0++, (D_800BE628 + (arg1 * 0x180) + (D_800BE9C0 * 0x10) + 0x40));
-//     // arg0->unk0 = 0xDC080008;
-//     // arg0->unk4 = (s32) (D_800BE628 + (temp_t6 * 0x180) + (D_800BE9C0 * 0x10) + 0x40);
-//     temp_s0 = func_1501A490(arg0, arg1, 0, 0, 0, 0);
-//     if ((D_800BEAC0 != 0) || (D_80084480 != 0)) {
-//         return temp_s0;
-//     }
-//
-//     temp_s0 = func_1510FEA0(temp_s0, D_800BE9F0);
-//     if ((func_1517EFAC(arg1) != 0) || ((D_800D18A0 & (1 << arg1)) != 0)){
-//         return temp_s0;
-//     }
-//
-//     temp_s0 = func_1515D6D0(temp_s0, arg1);
-//     temp_s0 = func_1510B9D0(temp_s0, arg1);
-//     return temp_s0;
-//
-// }
+void *func_15019464(Gfx *arg0, s16 arg1) {
+    func_1510B958(arg1);
+    gSPViewport(arg0++, (s32)((u8 *)D_800BE628 + arg1 * 0x180) + D_800BE9C0 * 0x10 + 64);
+    arg0 = (Gfx *)func_1501A490((s32)arg0, arg1, 0, 0, 0, 0);
+    if (D_800BEAC0 != 0) {
+        return arg0;
+    }
+    if (D_80084480 != 0) {
+        return arg0;
+    }
+    arg0 = (Gfx *)func_1510FEA0((s32)arg0, D_800BE9F0);
+    if ((func_1517EFAC(arg1) != 0) || ((D_800D18A0 & (1 << arg1)) != 0)) {
+        return arg0;
+    }
+    arg0 = (Gfx *)func_1515D6D0((s32)arg0, arg1);
+    arg0 = (Gfx *)func_1510B9D0((s32)arg0, arg1);
+    return arg0;
+}
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_45B80/func_150195A0.s")
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_45B80/func_150198FC.s")
 
-#pragma GLOBAL_ASM("asm/nonmatchings/game_45B80/func_15019BB8.s")
-// NON-MATCHING: need to figure out what is going on
-// void func_15019BB8(struct14 *arg0, s32 arg1) {
-//     s32 temp_v0;
-//     s32 sp2A;
-//     s16 sp28;
-//
-//     arg0->unk0 = 0xDC080008;
-//     arg0->unk4 = &D_800BE628[arg1].unk40[D_800BE9C0];
-//     sp28 = arg1;
-//
-//     temp_v0 = func_1501A490(&arg0->unk8, &sp28, 0, 0, 0, 0);
-//     temp_v0 = func_1517F4D8(temp_v0, arg1);
-//     temp_v0 = func_1517F3A0(temp_v0, arg1);
-//     temp_v0 = func_15180580(temp_v0, arg1);
-//     // temp_v1 = 1 << arg1;
-//     if (((D_800D18A0 & (1 << arg1)) != 0) || ( ((D_800D18A2 & (1 << arg1)) != 0))) {
-//         temp_v0 = func_1507DB6C(temp_v0, arg1);
-//     }
-//     temp_v0 = func_151674F8(temp_v0, 4, sp2A, 0);
-//     func_151674F8(temp_v0, 4, sp2A, 1);
-// }
+void func_15019BB8(Gfx *arg0, s32 arg1) {
+    gSPViewport(arg0++, (s32)((u8 *)D_800BE628 + arg1 * 0x180) + D_800BE9C0 * 0x10 + 64);
+    arg0 = (Gfx *)func_1501A490((s32)arg0, arg1, 0, 0, 0, 0);
+    arg0 = (Gfx *)func_1517F4D8((s32)arg0, arg1);
+    arg0 = (Gfx *)func_1517F3A0((s32)arg0, arg1);
+    arg0 = (Gfx *)func_15180580((s32)arg0, arg1);
+    if ((D_800D18A0 & (1 << arg1)) || (D_800D18A2 & (1 << arg1))) {
+        arg0 = (Gfx *)func_1507DB6C((s32)arg0, arg1);
+    }
+    arg0 = (Gfx *)func_151674F8(arg0, 4, arg1, 0);
+    arg0 = (Gfx *)func_151674F8(arg0, 4, arg1, 1);
+}
 
+// NON-MATCHING: best 2922 (PERMUTER CANDIDATE). Algorithmically exact: branch,
+// gSPMatrix commands, D_800DC2A0[] access all correct. Only divergence is that IDO
+// homes arg1 to its stack arg-slot (0x44) and reloads on every use instead of
+// promoting it to $s0 like the target (target: `move s0,a1`). All ~2900 score comes
+// from that single allocation decision cascading register numbers + reload insns.
+// Needs the permuter to force arg1 into a callee-saved register.
+// void *func_15019CC8(Gfx *arg0, s32 arg1) {
+//     gSPViewport(arg0++, D_800BE628 + arg1 * 0x180 + D_800BE9C0 * 0x10 + 64);
+//     arg0 = (Gfx *)func_1501A490((s32)arg0, arg1, 0, 0, 0, 0);
+//     gSPMatrix(arg0++, &D_80089470, G_MTX_MODELVIEW | G_MTX_LOAD | G_MTX_NOPUSH);
+//     gSPMatrix(arg0++, D_800BE628 + arg1 * 0x180 + D_800BE9C0 * 0x40 + 0x100, G_MTX_PROJECTION | G_MTX_LOAD);
+//     if (D_800BE9F0 == 0x1D) {
+//         arg0 = (Gfx *)func_1502BAD0((s32)arg0, 6, arg1);
+//     }
+//     arg0 = (Gfx *)func_151674F8(arg0, 5, 0, 0);
+//     arg0 = (Gfx *)func_151674F8(arg0, 5, 0, 1);
+//     gSPMatrix(arg0++, D_800BE628 + arg1 * 0x180 + D_800BE9C0 * 0x40 + 0x100, G_MTX_PROJECTION | G_MTX_LOAD);
+//     gSPMatrix(arg0++, (s32)(&D_800DC2A0)[D_800BE9C0] + arg1 * 0x40, G_MTX_PROJECTION);
+//     return arg0;
+// }
 #pragma GLOBAL_ASM("asm/nonmatchings/game_45B80/func_15019CC8.s")
 
 void func_15019E60(Gfx *arg0) {

--- a/conker/src/game_476D0.c
+++ b/conker/src/game_476D0.c
@@ -5,42 +5,27 @@
 
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_476D0/func_1501A220.s")
-// NON-MATCHING: 80% there
+// PERMUTER CANDIDATE — best score 355. Logic is byte-correct (key insight: the
+// rounding is IDO's native signed `% 4`, and D_800968E0 must be bit-reinterpreted
+// as f32). Residual is a single register-allocation cascade: the target copies arg0
+// into a saved register (`move s1, a0`, reading `s1 + 2`) while IDO keeps it in a0
+// for this source; that one choice renames ~15 downstream temps. Reconstruction:
 // void func_1501A220(s32 arg0, s32 arg1) {
-//     s32 phi_s0;
-//     s32 i;
-//
-//     f32 temp_f0;
-//     s32 temp_f16;
-//
+//     s32 phi_s0, i, temp_f16;
+//     f32 temp_f0, factor;
 //     D_80082FA0 = arg0;
-//
-//     if (arg0 == 0) {
-//         phi_s0 = 1;
-//     } else {
-//         phi_s0 = arg0 + 2;
-//     }
+//     if (arg0 == 0) { phi_s0 = 1; } else { phi_s0 = arg0 + 2; }
 //     D_800BE628 = allocate_memory((phi_s0 * 3) << 7, 1, 1, 0);
 //     D_800BE62C = allocate_memory(phi_s0 * 16, 1, 1, 0);
 //     if (D_80082FA0 == 1) {
-//         temp_f0 = D_800BE63C - 2.0f;
-//         temp_f16 = temp_f0 * D_800968E0;
-//         phi_s0 = temp_f16 & 3;
-//         if ((temp_f16 < 0) && ((temp_f16 & 3) != 0)) {
-//             phi_s0 -= 4;
-//         }
-//         D_800BE6B8 = (temp_f16 - phi_s0) / temp_f0;
+//         temp_f0 = (f32) D_800BE63C[0] - 2.0f;
+//         factor = *(f32 *) &D_800968E0;
+//         temp_f16 = temp_f0 * factor;
+//         D_800BE6B8 = (f32) (temp_f16 - temp_f16 % 4) / temp_f0;
 //     }
-//
 //     func_150006E0(D_800BE9F0);
-//
-//     for(i = 0; i <= D_80082FA0; i++) {
-//         func_1501A8C0(i, D_80082FA0, 1023, 0);
-//     }
-//     if (D_80082FA0 != 0) {
-//         func_1501A8C0(i, 0, 1023, 0);
-//     }
-//
+//     for (i = 0; i <= D_80082FA0; i++) { func_1501A8C0(i, D_80082FA0, 1023, 0); }
+//     if (D_80082FA0 != 0) { func_1501A8C0(i, 0, 1023, 0); }
 //     D_800BE617 = 1;
 //     D_800BE614 = 1;
 //     D_800BE635 = 0;
@@ -48,23 +33,63 @@
 // }
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_476D0/func_1501A39C.s")
-// NON-MATCHING: something along these lines
-// extern Gfx* D_800BE9C8;
-// extern s32 D_8002C930;
-// Gfx *func_1501A39C(void) {
-//     s32 i;
-//     Gfx *tmp = D_800BE9C8;
-//     for (i = 0; i < 3; i++) {
-//         gSPSegment(tmp++, 0x00, 0x00000000);
-//         gSPSegment(tmp++, 0x00, 0x00000000);
-//         gSPDisplayList(tmp++, D_8002C930);
-//         gDPSetDepthImage(tmp++, D_800BE9C4);
-//         gSPViewport(tmp++, D_800BE628 + i + 0x40);
-//     }
-//     return tmp;
+// NON-MATCHING (structural): logic is a 2-iteration do-while over two Gfx* arrays.
+// Correct behavior; blocker is IDO computing the runtime trip count
+// (end-start)/stride and unrolling/peeling the loop (best 7631), whereas the target
+// keeps a compact single-body do-while with a per-iteration `bne dst, &D_800BE9E0`.
+// Could not suppress the unroll from C. Reconstruction:
+// extern Gfx *D_800BE9C8[];
+// extern Gfx D_8002C930[];
+// void func_1501A39C(void) {
+//     Gfx **src = D_800BE9C8;
+//     s32 *dst = D_800BE9D8;
+//     s32 off = 0;
+//     Gfx *g;
+//     do {
+//         g = *src;
+//         gSPSegment(g++, 0, 0);
+//         gSPSegment(g++, 0, 0);
+//         gSPDisplayList(g++, D_8002C930);
+//         gDPSetDepthImage(g++, D_800BE9C4);
+//         gSPViewport(g++, D_800BE628 + off + 0x40);
+//         src++;
+//         off += 0x10;
+//         *dst++ = (s32)g;
+//     } while (dst != &D_800BE9E0);
 // }
 
+// structs.h struct259 has an opaque unk0[0x74]; declare a file-local view of
+// the 0x24..0x30 float fields. D_800BE628 is typed s32 but holds a pointer.
+typedef struct {
+    u8  pad0[0x24];
+    f32 unk24;
+    f32 unk28;
+    f32 unk2C;
+    f32 unk30;
+    u8  pad34[0x14C];
+} struct259_local; // size 0x180
+
 #pragma GLOBAL_ASM("asm/nonmatchings/game_476D0/func_1501A490.s")
+// NON-MATCHING: gDPPipeSync + gDPSetScissor display-list builder. functions.h wrongly declares this
+// s32/s32; the real signature is Gfx*/Gfx* (siblings func_15142C10/func_15142CF0). At s32 the best is
+// 1596; correcting the header to Gfx* drops it to 674 but a -g3 frame/register near-miss remains (not 0).
+// Reconstruction (needs the Gfx*/Gfx* header + `void func_1501AF44(f32*,f32*,f32*,f32*);` fwd-declared):
+// Gfx *func_1501A490(Gfx *gfx, s16 arg1, s32 arg2, s32 arg3, s32 arg4, s32 arg5) {
+//     gDPPipeSync(gfx++);
+//     if (arg1 == 0xFF) {
+//         gDPSetScissor(gfx++, arg5, 2, 0, D_800BE620 - 2, D_800BE624);
+//     } else {
+//         struct259_local *s = &((struct259_local *) D_800BE628)[arg1];
+//         f32 sp3C = s->unk2C, sp38 = s->unk30, sp34 = s->unk24, sp30;
+//         if (arg4 != 0) {
+//             f32 fa4 = (f32) arg4;
+//             if (fa4 < s->unk28) { sp30 = fa4; } else { sp30 = s->unk28; }
+//         } else { sp30 = s->unk28; }
+//         func_1501AF44(&sp3C, &sp34, &sp38, &sp30);
+//         gDPSetScissor(gfx++, arg5, sp3C, sp34, sp38, sp30);
+//     }
+//     return gfx;
+// }
 
 Gfx *func_1501A680(Gfx *arg0) {
     gDPSetColorImage(arg0++, G_IM_FMT_RGBA, G_IM_SIZ_16b, D_800BE620, D_8002AAE8[D_800BE9C0]);
@@ -89,50 +114,135 @@ Gfx *func_1501A6CC(Gfx *arg0, s32 a, s32 b, s32 c, s32 d) {
     return arg0;
 }
 
-void func_150A7A00(f32 arg0, f32 arg1, s32 arg2, f32 arg3, f32 arg4, f32 arg5, f32* arg6, f32* arg7, f32* arg8, f32* arg9);
-#pragma GLOBAL_ASM("asm/nonmatchings/game_476D0/func_1501A764.s")
-// void func_1501A764(s16 arg0, f32 arg1, f32 arg2, f32 arg3, f32 *arg4, f32 *arg5, f32 *arg6) {
-//     f32 sp34;
-//     f32 sp30;
-//     f32 sp2C;
-//     f32 sp28;
-//     struct140 *temp_v0_2;
-//
-//     func_150A7A00(arg1, arg2, &D_800D9D10 + (arg0 << 6), arg1, arg2, arg3, &sp34, &sp30, &sp2C, &sp28);
-//     sp28 = 1.0f / sp28;
-//     // temp_v1 = arg0 * 0x180;
-//     temp_v0_2 = &D_800BE628[arg0];
-//     // sp28 = temp_f8;
-//     *arg4 = (((temp_v0_2->unkC + 5.0f) * sp34 * sp28) + temp_v0_2->unk34);
-//     temp_v0_2 = &D_800BE628 [arg0];
-//     *arg5 = (temp_v0_2->unk38 - ((temp_v0_2->unk10 + 5.0f) * sp30 * sp28));
-//     temp_v0_2 = &D_800BE628[arg0].unk50[D_800BE9C0];  // (D_800BE9C0 * 0x10);
-//     *arg6 = (((f32) temp_v0_2->unk4C + (sp2C * sp28 * (f32) temp_v0_2->unk44)) * 32.0f);
-// }
+void func_150A7A00(s32 arg0, f32 arg1, f32 arg2, f32 arg3, f32* arg4, f32* arg5, f32* arg6, f32* arg7);
+
+typedef struct {
+    s16 unk0;
+    u8  pad2[6];
+    s16 unk8;
+    u8  padA[6];
+} A764Sub; // 0x10
+
+typedef struct {
+    u8  pad0[0xC];
+    f32 unkC;
+    f32 unk10;
+    u8  pad14[0x20];
+    f32 unk34;
+    f32 unk38;
+    u8  pad3C[0x8];
+    A764Sub unk44[19];
+    u8  pad174[0xC];
+} A764Elem; // 0x180
+
+#define A764_ELEM(i) (((A764Elem *) D_800BE628)[i])
+
+void func_1501A764(s16 arg0, f32 arg1, f32 arg2, f32 arg3, f32 *arg4, f32 *arg5, f32 *arg6) {
+    f32 sp34;
+    f32 sp30;
+    f32 sp2C;
+    f32 sp28;
+
+    func_150A7A00((s32) D_800D9D10 + (arg0 << 6), arg1, arg2, arg3, &sp34, &sp30, &sp2C, &sp28);
+    sp28 = 1.0f / sp28;
+    *arg4 = A764_ELEM(arg0).unk34 + ((A764_ELEM(arg0).unkC + 5.0f) * sp34 * sp28);
+    *arg5 = A764_ELEM(arg0).unk38 - ((A764_ELEM(arg0).unk10 + 5.0f) * sp30 * sp28);
+    *arg6 = (((sp2C * sp28) * (f32) A764_ELEM(arg0).unk44[D_800BE9C0].unk0) +
+             (f32) A764_ELEM(arg0).unk44[D_800BE9C0].unk8) * 32.0f;
+}
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_476D0/func_1501A8C0.s")
 
-#pragma GLOBAL_ASM("asm/nonmatchings/game_476D0/func_1501AE94.s")
+s32 func_1501AE94(s32 arg0) {
+    f32 w = (f32) D_800BE620 - 2.0f;
+    f32 h = (f32) D_800BE624;
+    struct259_local *sp = &((struct259_local *) D_800BE628)[arg0];
 
-#pragma GLOBAL_ASM("asm/nonmatchings/game_476D0/func_1501AF44.s")
+    if ((sp->unk2C < 2.0f) || (w < sp->unk30)) {
+        return 0;
+    }
+    if ((sp->unk24 < 0.0f) || (h < sp->unk28)) {
+        return 0;
+    }
+    return 1;
+}
+
+void func_1501AF44(f32 *a0, f32 *a1, f32 *a2, f32 *a3) {
+    f32 v;
+    f32 hi;
+    f32 result;
+
+    v = *a0;
+    if (v < 2.0f) {
+        *a0 = 2.0f;
+    } else {
+        hi = (f32) D_800BE620 - 2.0f;
+        result = (hi < v) ? hi : v;
+        *a0 = result;
+    }
+
+    v = *a2;
+    if (v < 2.0f) {
+        *a2 = 2.0f;
+    } else {
+        hi = (f32) D_800BE620 - 2.0f;
+        result = (hi < v) ? hi : v;
+        *a2 = result;
+    }
+
+    v = *a1;
+    if (v < 0.0f) {
+        *a1 = 0.0f;
+    } else {
+        hi = (f32) D_800BE624 - 0.0f;
+        result = (hi < v) ? hi : v;
+        *a1 = result;
+    }
+
+    v = *a3;
+    if (v < 0.0f) {
+        *a3 = 0.0f;
+    } else {
+        hi = (f32) D_800BE624 - 0.0f;
+        result = (hi < v) ? hi : v;
+        *a3 = result;
+    }
+}
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_476D0/func_1501B0A0.s")
+// permuter NO ZERO, best 275
+// NON-MATCHING: best 275 — PERMUTER CANDIDATE. Logic is byte-identical to the target;
+// the ONLY residual is instruction scheduling: IDO hoists the `lwc1 f0, D_800968F4`
+// constant load to the top of the prologue (before `sw ra`), while for this source it
+// schedules that load next to its first use. Every other instruction matches 1:1 and
+// the frame (0x50) is exact. D_800968F4/F8/FC are undeclared rodata f32 consts (need
+// file-local externs); func_1510B128(s32,f32,f32,f32,f32); D_800BE638/D_800BE650 are
+// scalar-typed in the header so index via (&D_800BE638)[arg1]. Reconstruction:
+// extern f32 D_800968F4, D_800968F8, D_800968FC;
+// void func_1510B128(s32, f32, f32, f32, f32);
+// typedef struct { u8 pad0[0xC]; f32 unkC, unk10; u8 pad14[0x58]; f32 unk6C, unk70;
+//                  u8 pad74[0x10C]; } B0A0Elem; // 0x180
+// #define B0A0_ELEM(i) (((B0A0Elem *) D_800BE628)[i])
+// void func_1501B0A0(s32 arg0, s32 arg1) {
+//     f32 a = B0A0_ELEM(arg0).unk6C * D_800968F4;
+//     f32 b = B0A0_ELEM(arg0).unk70 * D_800968F4;
+//     f32 tan_a = sinf(a) / cosf(a);
+//     f32 tan_b = sinf(b) / cosf(b);
+//     f32 xa = (f32) (&D_800BE638)[arg1] / (tan_a + tan_a);
+//     f32 xb = (f32) (&D_800BE650)[arg1] / (tan_b + tan_b);
+//     f32 f6 = func_150484A0(B0A0_ELEM(arg0).unkC, xa) * D_800968F8 - B0A0_ELEM(arg1).unk6C;
+//     f32 f2 = func_150484A0(B0A0_ELEM(arg0).unk10, xb) * D_800968FC - B0A0_ELEM(arg1).unk70;
+//     func_1510B128(arg0, f6, f2, 1.0f, 0.0f);
+// }
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_476D0/func_1501B22C.s")
-// JUSTREG: I think?
+// PERMUTER CANDIDATE — best score 471 (logic byte-correct; residual is FP spill-slot
+// coalescing in block1 (sp20/sp30 vs target sp24/sp34) + a byte-identical f12<->f2
+// register cascade in block2). Reconstruction that reaches 471:
 // void func_1501B22C(s32 arg0) {
-//     f32 tmp0;
-//     f32 tmp1;
-//     f32 tmp2;
-//     f32 tmp3;
-//     f32 tmp4;
-//     f32 tmp5;
-//     f32 tmp6;
-//     f32 tmp7;
-//
 //     struct259 *temp_s0;
-//
-//     temp_s0 = D_800BE628 + (arg0 * 0x180);
+//     f32 tmp0, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7;
+//     temp_s0 = (struct259 *) (arg0 * 0x180 + D_800BE628);
 //     tmp0 = temp_s0->unk74 * 0.5f;
 //     tmp7 = -tmp0;
 //     tmp5 = temp_s0->unk78 * 0.5f;
@@ -142,19 +252,19 @@ void func_150A7A00(f32 arg0, f32 arg1, s32 arg2, f32 arg3, f32 arg4, f32 arg5, f
 //     temp_s0->unk9C = tmp7;
 //     temp_s0->unk90 = tmp7;
 //     tmp3 = -tmp3;
-//     temp_s0->unk88 = -tmp3;
 //     temp_s0->unk94 = tmp3;
+//     temp_s0->unk88 = -tmp3;
 //     temp_s0->unk98 = 0.0f;
 //     temp_s0->unk8C = 0.0f;
 //     tmp6 = tmp5 * D_80096904;
 //     tmp2 = cosf(tmp6);
 //     tmp0 = sinf(tmp6);
-//     tmp4 = -tmp2;
 //     tmp0 = -tmp0;
 //     temp_s0->unkA0 = 0.0f;
-//     temp_s0->unkB0 = -tmp4;
 //     temp_s0->unkA8 = tmp0;
 //     temp_s0->unkB4 = tmp0;
+//     tmp4 = -tmp2;
 //     temp_s0->unkAC = 0.0f;
 //     temp_s0->unkA4 = tmp4;
+//     temp_s0->unkB0 = -tmp4;
 // }

--- a/conker/src/game_57FA0.c
+++ b/conker/src/game_57FA0.c
@@ -1,9 +1,24 @@
 #include <ultra64.h>
+#include <libc/stdarg.h>
 
+#define func_1502B7F0 func_1502B7F0_hdrdecl
 #include "functions.h"
+#undef func_1502B7F0
 #include "variables.h"
 
 #include "macros.h"
+
+extern u8 D_AB1950[];
+
+s32 func_1502AC88(s32 offset, s32 val, s32 *out);
+s32 func_1502AF04(s32 offset, s32 arg1, s32 val, s32 arg3);
+s32 func_1502B224(s32 arg0, s32 arg1, s32 hdr, s32 arg3);
+s32 func_1502B350(s32 offset, s32 hdr, s32 *out);
+s32 func_1502B4A8(s32 base, s32 count);
+
+s32 allocate_memory(s32 size, s32 arg1, s32 arg2, s32 arg3);
+s32 func_10006240(s32 arg0, s32 arg1, u32 arg2);
+void func_10004074(s32 arg0);
 
 void func_1502AAF0(void) {
 }
@@ -11,84 +26,387 @@ void func_1502AAF0(void) {
 void func_1502AAF8(s32 arg0) {
 }
 
+// NON-MATCHING (best 4286): algorithmically exact; both loops unroll by 4 like the target.
+// Remaining diffs are not hand-controllable: the target's main fill loop is software-pipelined
+// across 5 leading pointer registers (v0/v1/a0/a1/a2, +0x38 lead) producing a strength-reduced
+// end pointer that relocates against the separate symbol D_800C3EA0 (= D_800C3D68+0x138); a
+// plain C loop uses one base pointer + D_800C3D68+0x100 end. Also count wants saved-reg s2 and
+// the guard wants sltiu vs slti. Same compiler-scheduling class as func_1502B4A8.
+// typedef struct { s32 unk0, unk4, unk8, unkC; } AB04Entry;  extern AB04Entry D_800C3D68[16];
+// void func_1502AB04(s32 count, s32 *src, s32 a2, s32 a3) {
+//     s32 i;
+//     if (count != 0) {
+//         bcopy(&D_800C3D68[count], D_800C3D68, (16 - count) * 16);
+//     }
+//     for (i = 16 - count; i < 16; i++) {
+//         D_800C3D68[i].unk0 = a3;
+//         D_800C3D68[i].unk4 = a2;
+//         D_800C3D68[i].unk8 = src[0];
+//         D_800C3D68[i].unkC = src[1];
+//         a3 += 8;
+//         src += 2;
+//     }
+// }
 #pragma GLOBAL_ASM("asm/nonmatchings/game_57FA0/func_1502AB04.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/game_57FA0/func_1502AC88.s")
+// PERMUTER CANDIDATE (best 1501): algorithmically exact; structure + unrolled loop
+// match, remaining diffs are register allocation (dram wants saved s2 but lands in a
+// temp+spill; temp renames in the unrolled body; induction-var init moves).
+// s32 func_1502AF04(s32 offset, s32 arg1, s32 val, s32 count) {
+//     s32 q;
+//     s32 dram;
+//     s32 *data;
+//     s32 i;
+//
+//     val = val * 8;
+//     q = offset + val;
+//     dram = (arg1 + 8) & ~0xF;
+//     func_10004514(q & ~0xF, dram, ALIGN16((q & 0xE) + count * 8), 1);
+//
+//     data = (s32 *)(dram + (q & 0xF));
+//     for (i = 0; i != count; i++) {
+//         data[i * 2] += offset;
+//     }
+//
+//     return dram + (q & 0xF);
+// }
 #pragma GLOBAL_ASM("asm/nonmatchings/game_57FA0/func_1502AF04.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_57FA0/func_1502B020.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_57FA0/func_1502B110.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_57FA0/func_1502B224.s")
+s32 func_1502B020(s32 *arg0, s32 count, ...) {
+    va_list ap;
+    s32 offset;
+    s32 val;
+    s32 more;
+
+    more = 1;
+    offset = (s32)D_AB1950;
+    va_start(ap, count);
+
+    for (; count != 0; count--) {
+        val = va_arg(ap, s32);
+        if (more != 0) {
+            offset += func_1502AC88(offset, val, &more);
+        }
+        more = more & 0xFFFFFFF;
+    }
+
+    if (arg0 != 0) {
+        *arg0 = more & 0xFFFFFFF;
+    }
+
+    if (more == 0) {
+        return 0;
+    }
+    return offset;
+}
+s32 func_1502B110(s32 offset, s32 arg1, s32 arg2, u32 count, ...) {
+    va_list ap;
+    s32 val;
+    s32 more;
+    s32 result;
+
+    more = 1;
+    result = 0;
+    if (offset == 0) {
+        offset = (s32)D_AB1950;
+    }
+    va_start(ap, count);
+
+    for (; count >= 2; count--) {
+        val = va_arg(ap, s32);
+        if (more != 0) {
+            offset += func_1502AC88(offset, val, &more);
+        }
+        more = more & 0xFFFFFFF;
+    }
+
+    val = va_arg(ap, s32);
+    if (more != 0) {
+        result = func_1502AF04(offset, arg2, val, arg1);
+    }
+
+    return result;
+}
+s32 func_1502B224(s32 arg0, s32 arg1, s32 hdr, s32 arg3) {
+    s32 size;
+    s32 *ptr;
+    s32 checksum;
+
+    size = ALIGN2(hdr & 0xFFFFFFF);
+    if (arg3 != 0) {
+        if ((u32)arg3 < (u32)size) {
+            size = arg3;
+        }
+    }
+
+    if ((hdr & 0x70000000) == 0x10000000) {
+        ptr = (s32 *)allocate_memory(size, 1, 2, 2);
+        if (ptr == 0) {
+            return 0;
+        }
+        func_10004514(arg0, ptr, ALIGN16(size), 1);
+        checksum = *ptr & 0x7FFFFFFF;
+        size = func_10006240((s32)ptr, arg1, D_8003809C);
+        if (size != checksum) {
+            D_8003C8E0 = 0xC000036;
+            func_150AD770();
+        }
+        func_10004074((s32)ptr);
+        return size;
+    } else {
+        func_10004514(arg0, arg1, ALIGN16(size), 1);
+        return size;
+    }
+}
+// PERMUTER CANDIDATE (best ~1449): algorithmically exact; structure matches (result in s0,
+// size double-homed, all calls/branches aligned). Remaining diffs are register allocation:
+// -g3 frame is 0x38 vs 0x30 (ptr/outval stack slots don't pack the same) + temp-register
+// renames (v1<->t0, t2<->t4). Not hand-crackable; hand off to permuter.
+// s32 func_1502B350(s32 offset, s32 hdr, s32 *out) {
+//     s32 size;
+//     s32 *ptr;
+//     s32 checksum;
+//     s32 outval;
+//     s32 result;
+//
+//     size = ALIGN2(hdr & 0xFFFFFFF);
+//     outval = size;
+//     ptr = (s32 *)allocate_memory(size, 1, 2, 2);
+//     result = (s32)ptr;
+//     if (ptr == 0) {
+//         return 0;
+//     }
+//     func_10004514(offset, ptr, ALIGN16(size), 1);
+//     if ((hdr & 0x70000000) == 0x10000000) {
+//         checksum = *ptr & 0x7FFFFFFF;
+//         *out = checksum;
+//         if (checksum != 0) {
+//             result = 0;
+//             if ((u32)checksum < 0xF4240) {
+//                 result = allocate_memory(checksum, 1, 2, 2);
+//                 if (result != 0) {
+//                     outval = func_10006240((s32)ptr, result, D_8003809C);
+//                 } else {
+//                     outval = 0;
+//                 }
+//             } else {
+//                 outval = 0;
+//             }
+//         } else {
+//             result = 0;
+//             outval = 0;
+//         }
+//         func_10004074((s32)ptr);
+//     }
+//     *out = outval;
+//     return result;
+// }
 #pragma GLOBAL_ASM("asm/nonmatchings/game_57FA0/func_1502B350.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_57FA0/func_1502B4A8.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_57FA0/func_1502B5C8.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_57FA0/func_1502B6BC.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/game_57FA0/func_1502B7F0.s")
-// void func_1502B7F0(s32 *arg0, s32 arg1, s32 arg2, s32 arg3) {
-//     s32 sp38;
-//     s32 sp34;
-//     s32 temp_s1;
-//     s32 offset;
-//     s32 i;
+typedef struct {
+    s32 unk0;
+    u32 unk4;
+} B4A8Entry;
+
+// NON-MATCHING (best 6365): algorithmically exact. Per-entry bodies + software-pipelined
+// do-while match the target, but IDO auto-unrolls the relocation loop by 4 while the target
+// is unrolled by 2 (stride 0x10). The unroll factor is an IDO heuristic not controllable from
+// C (simple loop -> 4; manual unroll-by-2 gets re-unrolled to 4/8) and is not permuter-fixable.
+// Minor remaining diff: auto-detect loop uses beqzl vs target's sltiu+bnezl boolean.
+// s32 func_1502B4A8(s32 base, s32 count) {
+//     B4A8Entry *e;
+//     s32 w0;
+//     u32 w1;
+//     u32 w1c;
 //
-//     sp38 = 1;
-//     offset = &D_00AB1950; // 0xAB1950 - assets offsets table
-//     temp_s1 = &arg2;
-//
-//     i = arg1;
-//     if (i != 0) {
+//     if (count == 0) {
+//         e = (B4A8Entry *)(base + count * 8);
 //         do {
-//             temp_s1 = ALIGN4(temp_s1);
-//             if (sp38 != 0) {
-//                 offset += func_1502AC88(offset, temp_s1, &sp34);
+//             w1 = e->unk4;
+//             e++;
+//             count++;
+//         } while ((w1 & 0x80000000) == 0);
+//     }
+//
+//     if (count > 0) {
+//         B4A8Entry *end;
+//         e = (B4A8Entry *)base;
+//         end = (B4A8Entry *)(base + count * 8);
+//         do {
+//             w1c = e->unk4 & 0xFFFFFFF;
+//             e->unk4 = w1c;
+//             w0 = e->unk0;
+//             if (w0 != -1 && w1c != 0) {
+//                 e->unk0 = w0 + base;
+//             } else {
+//                 e->unk0 = 0;
 //             }
-//             sp38 = sp34 & 0xFFFFFFF;
-//             temp_s1 += 1;
-//         } while (i-- != 0);
+//             e++;
+//         } while (e != end);
 //     }
 //
-//     if (sp38 != 0) {
-//         *arg0 = func_1502B350(offset, sp34, &sp38);
-//     } else {
-//         *arg0 = 0;
-//     }
+//     return count;
 // }
+#pragma GLOBAL_ASM("asm/nonmatchings/game_57FA0/func_1502B4A8.s")
+s32 func_1502B5C8(s32 *arg0, s32 count, ...) {
+    va_list ap;
+    s32 offset;
+    s32 val;
+    s32 localbuf;
+    s32 ret;
+    s32 stack0;
+    s32 *p;
 
-#pragma GLOBAL_ASM("asm/nonmatchings/game_57FA0/func_1502B8E0.s")
+    p = &localbuf;
+    if (arg0 != 0) {
+        p = arg0;
+    }
+    *p = 1;
+    offset = (s32)D_AB1950;
+    va_start(ap, count);
 
-#pragma GLOBAL_ASM("asm/nonmatchings/game_57FA0/func_1502B9B4.s")
-// NON-MATCHING: maybe 50% there?
-// s32 func_1502B9B4(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
-//
-//     s32 stack2[2];
-//     s32 stack1[2];
-//     s32 stack0[5];
-//
-//     s32 more;
-//     s32 offset;
-//     s32 *tmp;
-//     s32 i;
-//
-//     more = 1;
-//     offset = &D_00AB1950;
-//     tmp = &arg1;
-//
-//     for (i = arg0; i != 0; i--) {
-//         tmp = ALIGN4(tmp) + 4;
-//         if (more != 0) {
-//             offset += func_1502AC88(offset, tmp - 4, &stack0);
-//         }
-//         more = *stack0 & 0xFFFFFFF;
-//     }
-//
-//     if (more != 0) {
-//         more = ALIGN2(stack0[0] & 0xFFFFFFF);
-//         if ((*stack0 & 0x70000000) == 0x10000000) {
-//             if (((s32) &stack1 & 8) != 0) {
-//                 *stack1 = &stack2;
-//             }
-//             func_10004514(offset, stack1, 0x10, 1); // decompress?
-//             more = *stack1;
-//         }
-//     }
-//
-//     return more;
-// }
+    for (; count != 0; count--) {
+        val = va_arg(ap, s32);
+        if (*p != 0) {
+            offset += func_1502AC88(offset, val, &stack0);
+        }
+        *p = stack0 & 0xFFFFFFF;
+    }
+
+    if (*p != 0) {
+        ret = func_1502B350(offset, stack0, p);
+    } else {
+        ret = 0;
+    }
+
+    return ret;
+}
+s32 func_1502B6BC(s32 *arg0, s32 arg1, s32 *arg2, s32 count, ...) {
+    va_list ap;
+    s32 offset;
+    s32 localbuf;
+    s32 val;
+    s32 *p;
+    s32 stack0;
+    s32 ptr;
+
+    p = &localbuf;
+    if (arg0 != 0) {
+        p = arg0;
+    }
+    *p = 1;
+    offset = (s32)D_AB1950;
+    va_start(ap, count);
+
+    for (; count != 0; count--) {
+        val = va_arg(ap, s32);
+        if (*p != 0) {
+            offset += func_1502AC88(offset, val, &stack0);
+        }
+        *p = stack0 & 0xFFFFFFF;
+    }
+
+    if (*p != 0) {
+        ptr = func_1502B350(offset, stack0, p);
+        if (*p != 0 && ptr != 0) {
+            arg1 = func_1502B4A8(ptr, arg1);
+        } else {
+            arg1 = 0;
+        }
+        if (arg2 != 0) {
+            *arg2 = arg1;
+        }
+    } else {
+        ptr = 0;
+    }
+
+    return ptr;
+}
+s32 func_1502B7F0(s32 *arg0, s32 count, ...) {
+    va_list ap;
+    s32 offset;
+    s32 val;
+    s32 more;
+    s32 stack0;
+
+    more = 1;
+    offset = (s32)D_AB1950;
+    va_start(ap, count);
+
+    for (; count != 0; count--) {
+        val = va_arg(ap, s32);
+        if (more != 0) {
+            offset += func_1502AC88(offset, val, &stack0);
+        }
+        more = stack0 & 0xFFFFFFF;
+    }
+
+    if (more != 0) {
+        *arg0 = func_1502B350(offset, stack0, &more);
+    } else {
+        *arg0 = 0;
+    }
+
+    return more;
+}
+
+s32 func_1502B8E0(s32 arg0, s32 arg1, s32 count, ...) {
+    va_list ap;
+    s32 more;
+    s32 offset;
+    s32 val;
+    s32 stack0;
+
+    more = 1;
+    offset = (s32)D_AB1950;
+    va_start(ap, count);
+
+    while (count != 0) {
+        val = va_arg(ap, s32);
+        if (more != 0) {
+            offset += func_1502AC88(offset, val, &stack0);
+        }
+        count--;
+        more = stack0 & 0xFFFFFFF;
+    }
+
+    if (more != 0) {
+        more = func_1502B224(offset, arg0, stack0, arg1);
+    }
+
+    return more;
+}
+
+s32 func_1502B9B4(s32 count, ...) {
+    va_list ap;
+    s32 offset;
+    s32 val;
+    s32 more;
+    s32 stack0;
+    s32 buf[7];
+    s32 *p;
+
+    more = 1;
+    offset = (s32)D_AB1950;
+    va_start(ap, count);
+
+    for (; count != 0; count--) {
+        val = va_arg(ap, s32);
+        if (more != 0) {
+            offset += func_1502AC88(offset, val, &stack0);
+        }
+        more = stack0 & 0xFFFFFFF;
+    }
+
+    if (more != 0) {
+        more = ALIGN2(stack0 & 0xFFFFFFF);
+        if ((stack0 & 0x70000000) == 0x10000000) {
+            p = buf;
+            if (((s32)p & 8) != 0) {
+                p = buf + 2;
+            }
+            func_10004514(offset, p, 0x10, 1);
+            more = *p;
+        }
+    }
+
+    return more;
+}


### PR DESCRIPTION
Byte-perfect (asm-differ score 0) decompiled functions across 13 file(s) in the game-20xx-5Fxx area, verified against the retail US ROM (sha1 842e3d34...). Non-matching functions remain GLOBAL_ASM pragmas; near-miss reconstructions are kept as comments for future work. Depends on matches/00-build-config (per-file OPT_FLAGS + variables.h extern).