### PR TITLE
Match functions in init

### DIFF
--- a/conker/src/init_1AAE0.c
+++ b/conker/src/init_1AAE0.c
@@ -2,99 +2,181 @@
 
 void __n_resetPerfChanState(N_ALSeqPlayer *seqp, s32 chan);
 
-#pragma GLOBAL_ASM("asm/nonmatchings/init_1AAE0/func_1001AAE0.s")
-// void func_1001AAE0(void *arg0, s32 arg1) {
-//     void *sp4;
-//     void *sp0;
-//     void *temp_t6;
-//
-//     sp4 = NULL;
-//     sp0 = arg0->unk64;
-//     if (sp0 != 0) {
-// loop_1:
-//         if ((sp0 + 4) == arg1) {
-//             if (sp4 != 0) {
-//                 *sp4 = (s32) *sp0;
-//             } else {
-//                 arg0->unk64 = (void *) *sp0;
-//             }
-//             if (arg0->unk68 == sp0) {
-//                 arg0->unk68 = sp4;
-//             }
-//             *sp0 = (void *) arg0->unk6C;
-//             arg0->unk6C = sp0;
-//             arg0->unk8D = (u8) (arg0->unk8D - 1);
-//             return;
-//         }
-//         sp4 = sp0;
-//         temp_t6 = *sp0;
-//         sp0 = temp_t6;
-//         if (temp_t6 != 0) {
-//             goto loop_1;
-//         }
-//     }
-// }
+// File-local view of the object passed to func_1001BD34/func_1001BE1C; it holds
+// a pair of callbacks at 0x28/0x30 and has no type in the shared headers yet.
+typedef struct {
+    u8   pad0[0x30];
+    void (*unk30)(void *);
+} InitBankCallbacks;
 
-#pragma GLOBAL_ASM("asm/nonmatchings/init_1AAE0/__n_seqpReleaseVoice.s")
-// void __n_seqpReleaseVoice(void *arg0, void *arg1, s32 arg2) {
-//     void *sp3C;
-//     s16 sp38;
-//     void *sp34;
-//     void *sp30;
-//     void *sp2C;
-//     void *sp28;
-//     void *sp24;
-//     void *sp20;
-//     void *sp1C;
-//     void *sp18;
-//
-//     sp34 = arg1->unk10;
-//     if (sp34->unk38 == 0) {
-//         sp30 = arg0->unk50;
-//         if (sp30 != 0) {
-// loop_2:
-//             sp2C = *sp30;
-//             sp28 = sp30;
-//             sp24 = sp2C;
-//             if ((sp28->unkC == 6) && (sp28->unk10 == arg1)) {
-//                 if (sp24 != 0) {
-//                     sp24->unk8 = (s32) (sp24->unk8 + sp28->unk8);
-//                 }
-//                 sp20 = sp30;
-//                 if (sp20->unk0 != 0) {
-//                     sp20->unk0->unk4 = (s32) sp20->unk4;
-//                 }
-//                 if (sp20->unk4 != 0) {
-//                     *sp20->unk4 = (s32) sp20->unk0;
-//                 }
-//                 sp1C = sp30;
-//                 sp18 = arg0 + 0x48;
-//                 sp1C->unk0 = (s32) *sp18;
-//                 sp1C->unk4 = sp18;
-//                 if (*sp18 != 0) {
-//                     (*sp18)->unk4 = sp1C;
-//                 }
-//                 *sp18 = sp1C;
-//             }
-//             sp30 = sp2C;
-//             if (sp30 != 0) {
-//                 goto loop_2;
-//             }
-//         }
-//     }
-//     sp34->unk37 = (u8)0;
-//     sp34->unk38 = (u8)3;
-//     sp34->unk34 = (u8)0;
-//     sp34->unk28 = (s32) (arg0->unk1C + arg2);
-//     n_alSynSetPriority(arg1, 0);
-//     n_alSynSetVol(arg1, 0, arg2);
-//     sp38 = 5;
-//     sp3C = arg1;
-//     arg2 = arg2 + 0x7D00;
-//     n_alEvtqPostEvent(arg0 + 0x48, &sp38, arg2, 0);
-// }
+void func_1001AAE0(N_ALSeqPlayer *seqp, N_ALVoice *voice) {
+    N_ALVoiceState *last;
+    N_ALVoiceState *vs;
 
-#pragma GLOBAL_ASM("asm/nonmatchings/init_1AAE0/func_1001ADA4.s")
+    last = NULL;
+    vs = seqp->vAllocHead;
+
+    if (vs) do {
+        if (&vs->voice == voice) {
+            if (last) {
+                last->next = vs->next;
+            } else {
+                seqp->vAllocHead = vs->next;
+            }
+            if (seqp->vAllocTail == vs) {
+                seqp->vAllocTail = last;
+            }
+            vs->next = seqp->vFreeList;
+            seqp->vFreeList = vs;
+            seqp->usedVoices--;
+            return;
+        }
+        last = vs;
+    } while ((vs = vs->next) != NULL);
+}
+
+typedef struct RelNode {
+    struct RelNode *unk0;
+    struct RelNode *unk4;
+    s32             unk8;
+    s16             unkC;
+    u8              padE[0x2];
+    void           *unk10;
+} RelNode;
+
+typedef struct {
+    u8       pad0[0x1C];
+    s32      unk1C;
+    u8       pad20[0x28];
+    RelNode *unk48;
+    u8       pad4C[0x4];
+    RelNode *unk50;
+} RelSeqp;
+
+void __n_seqpReleaseVoice(RelSeqp *arg0, N_ALVoice *arg1, s32 arg2) {
+    N_ALEvent sp38;
+    N_ALVoiceState *sp34;
+    RelNode *sp30;
+    RelNode *sp2C;
+    RelNode *sp28;
+    RelNode *sp24;
+    RelNode *sp20;
+    RelNode *sp1C;
+    RelNode **sp18;
+
+    sp34 = arg1->unk10;
+    if (sp34->envPhase == 0) {
+        sp30 = arg0->unk50;
+        if (sp30 != 0) {
+            do {
+                sp2C = sp30->unk0;
+                sp28 = sp30;
+                sp24 = sp2C;
+                if (sp28->unkC == 6) {
+                    if (sp28->unk10 == arg1) {
+                        if (sp24 != 0) {
+                            sp24->unk8 += sp28->unk8;
+                        }
+                        sp20 = sp30;
+                        if (sp20->unk0 != 0) {
+                            sp20->unk0->unk4 = sp20->unk4;
+                        }
+                        if (sp20->unk4 != 0) {
+                            sp20->unk4->unk0 = sp20->unk0;
+                        }
+                        sp1C = sp30;
+                        sp18 = &arg0->unk48;
+                        sp1C->unk0 = *sp18;
+                        sp1C->unk4 = (RelNode *)sp18;
+                        if (*sp18 != 0) {
+                            (*sp18)->unk4 = sp1C;
+                        }
+                        *sp18 = sp1C;
+                    }
+                }
+                sp30 = sp2C;
+            } while (sp30 != 0);
+        }
+    }
+    sp34->velocity = 0;
+    sp34->envPhase = 3;
+    sp34->envGain = 0;
+    sp34->envEndTime = arg0->unk1C + arg2;
+    n_alSynSetPriority(arg1, 0);
+    n_alSynSetVol(arg1, 0, arg2);
+    sp38.type = 5;
+    sp38.msg.note.voice = arg1;
+    arg2 = arg2 + 0x7D00;
+    n_alEvtqPostEvent((ALEventQueue *)&arg0->unk48, &sp38, arg2, 0);
+}
+
+typedef struct EvtNode {
+    struct EvtNode *unk0;
+    struct EvtNode *unk4;
+    s32             unk8;
+    s16             unkC;
+    u8              padE[0x2];
+    void           *unk10;
+} EvtNode;
+
+typedef struct {
+    u8       pad0[0x48];
+    EvtNode *unk48;
+    u8       pad4C[0x4];
+    EvtNode *unk50;
+} EvtSeqp;
+
+s32 func_1001ADA4(EvtSeqp *seqp, void *arg1, s32 arg2) {
+    EvtNode *sp1C;
+    EvtNode *sp18;
+    EvtNode *sp14;
+    s32 sp10;
+    u8 spF;
+    EvtNode *sp8;
+    EvtNode *sp4;
+    EvtNode **sp0;
+
+    sp10 = 0;
+    spF = 1;
+    sp1C = seqp->unk50;
+    if (sp1C != 0) {
+        do {
+            sp18 = sp1C->unk0;
+            sp14 = sp1C;
+            sp10 += sp14->unk8;
+            if (sp14->unkC == 5) {
+                if (sp14->unk10 == arg1) {
+                    if (arg2 < sp10) {
+                        if (sp18 != 0) {
+                            sp18->unk8 += sp14->unk8;
+                        }
+                        sp8 = sp1C;
+                        if (sp8->unk0 != 0) {
+                            sp8->unk0->unk4 = sp8->unk4;
+                        }
+                        if (sp8->unk4 != 0) {
+                            sp8->unk4->unk0 = sp8->unk0;
+                        }
+                        sp4 = sp1C;
+                        sp0 = &seqp->unk48;
+                        sp4->unk0 = *sp0;
+                        sp4->unk4 = (EvtNode *)sp0;
+                        if (*sp0 != 0) {
+                            (*sp0)->unk4 = sp4;
+                        }
+                        *sp0 = sp4;
+                        goto done;
+                    }
+                    spF = 0;
+                done:
+                    break;
+                }
+            }
+            sp1C = sp18;
+        } while (sp1C != 0);
+    }
+    return spF;
+}
 
 N_ALVoiceState *__n_mapVoice(N_ALSeqPlayer *seqp, u8 key, u8 vel, u8 channel)
 {
@@ -128,9 +210,50 @@ N_ALVoiceState *__n_mapVoice(N_ALSeqPlayer *seqp, u8 key, u8 vel, u8 channel)
     return vs;
 }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/init_1AAE0/func_1001AFEC.s")
+N_ALVoiceState *func_1001AFEC(N_ALSeqPlayer *seqp, u8 key, u8 channel) {
+    N_ALVoiceState *vs;
 
-#pragma GLOBAL_ASM("asm/nonmatchings/init_1AAE0/func_1001B07C.s")
+    vs = seqp->vAllocHead;
+
+    while (vs) {
+        if (vs->key == key && vs->channel == channel && vs->phase != 3 && vs->phase != 4) {
+            return vs;
+        }
+        vs = vs->next;
+    }
+    return NULL;
+}
+
+ALSound *func_1001B07C(N_ALSeqPlayer *seqp, u8 key, u8 vel, u8 chan) {
+    ALInstrument *inst;
+    s32 lo;
+    s32 hi;
+    s32 mid;
+    ALKeyMap *keyMap;
+
+    inst = seqp->chanState[chan].instrument;
+    lo = 1;
+    if (inst == NULL) {
+        return NULL;
+    }
+    hi = inst->soundCount;
+    while (hi >= lo) {
+        mid = (lo + hi) / 2;
+        keyMap = inst->soundArray[mid - 1]->keyMap;
+        if (key >= keyMap->keyMin && key <= keyMap->keyMax &&
+            vel >= keyMap->velocityMin && vel <= keyMap->velocityMax) {
+            return inst->soundArray[mid - 1];
+        } else {
+            if (key < keyMap->keyMin ||
+                (vel < keyMap->velocityMin && key <= keyMap->keyMax)) {
+                hi = mid - 1;
+            } else {
+                lo = mid + 1;
+            }
+        }
+    }
+    return NULL;
+}
 
 s16 __n_vsVol(N_ALVoiceState *vs, N_ALSeqPlayer *seqp)
 {
@@ -150,17 +273,15 @@ s16 __n_vsVol(N_ALVoiceState *vs, N_ALSeqPlayer *seqp)
     return t1;
 }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/init_1AAE0/func_1001B310.s")
-// NON-MATCHING: missing a move
-// s32 func_1001B310(struct25 *arg0, struct26 *arg1) {
-//     s32 sp14;
-//     s32 sp10;
-//
-//     sp14 = arg1->unk60[arg0->unk35].unkA & 0x80;
-//     sp10 = ((arg1->unk60[arg0->unk35].unkA & 0x7F) + (s32) (arg1->unk7C * 127.0f)) * arg1->unk80;
-//
-//     return (MAX(0, MIN(127, sp10)) | sp14) & 0xff;
-// }
+s32 func_1001B310(N_ALVoiceState *vs, N_ALCSPlayer *seqp) {
+    s32 sp14;
+    s32 sp10;
+
+    sp14 = seqp->chanState[vs->channel].fxmix & 0x80;
+    sp10 = ((seqp->chanState[vs->channel].fxmix & 0x7F) + (s32) (seqp->unk7C * 127.0f)) * seqp->unk80;
+
+    return (MAX(0, MIN(127, sp10)) | sp14) & 0xff;
+}
 
 ALMicroTime __n_vsDelta(N_ALVoiceState *vs, ALMicroTime t) {
   /*
@@ -192,7 +313,24 @@ ALPan __n_vsPan(N_ALVoiceState *vs, N_ALSeqPlayer *seqp)
 }
 
 // not vanilla
-#pragma GLOBAL_ASM("asm/nonmatchings/init_1AAE0/__n_initFromBank.s")
+void __n_initFromBank(N_ALSeqPlayer *seqp, ALBank *b)
+{
+    s32 i;
+    ALInstrument *inst;
+
+    inst = NULL;
+    for (i = 1; inst == NULL; i++) {
+        inst = b->instArray[i];
+    }
+
+    for (i = 0; i < seqp->maxChannels; i++) {
+        __n_resetPerfChanState(seqp, i);
+    }
+
+    if (b->percussion) {
+        __n_resetPerfChanState(seqp, i);
+    }
+}
 
 void __n_initChanState(N_ALSeqPlayer *seqp)
 {
@@ -224,37 +362,212 @@ void __n_resetPerfChanState(N_ALSeqPlayer *seqp, s32 chan) {
     seqp->chanState[chan].unk8 = 0;
 }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/init_1AAE0/func_1001B7D0.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/init_1AAE0/func_1001BD34.s")
-// s32 func_1001BD34(void *arg0, void *arg1, s32 arg2) {
-//     void *sp1C;
-//     s32 sp18;
-//     s32 phi_v0;
-//
-//     sp18 = 0;
-//     sp1C = arg0->unk28();
-//     if (sp1C == 0) {
-//         return 0;
-//     }
-//     if (arg2 == -1) {
-//         phi_v0 = sp1C(arg1, 1);
-//     } else {
-//         phi_v0 = sp1C(*arg1 + (arg2 * 4) + 0x10, 0);
-//     }
-//     sp18 = phi_v0;
-//     if ((sp18 != 0) && ((sp18 & 0xFF000003) != 0x80000000)) {
-//         return 0;
-//     }
-//     return sp18;
-// }
+s32 func_1001BD34();
+void func_10012C5C(void *arg0, s32 arg1, s32 arg2);
 
-#pragma GLOBAL_ASM("asm/nonmatchings/init_1AAE0/func_1001BE1C.s")
-// void func_1001BE1C(void *arg0, s32 arg1, s32 arg2) {
-//     if (arg2 == -1) {
-//         arg0->unk30(arg1);
-//     } else {
-//         arg0->unk30((arg1 + (arg2 * 4))->unk10);
-//     }
-// }
+typedef struct {
+    void *unk0;
+    s16   unk4;
+    u8    unk6;
+    u8    unk7;
+    u8    unk8;
+    u8    unk9;
+    u8    padA[0x12];
+    s32   unk1C;
+    s32   unk20;
+    s32   unk24;
+    u8    unk28;
+    u8    unk29;
+    u8    unk2A;
+    u8    unk2B;
+    u8    unk2C;
+    u8    unk2D;
+    u8    unk2E;
+    u8    unk2F;
+    u8    unk30;
+    u8    unk31;
+    u8    unk32;
+    u8    unk33;
+    u8    unk34;
+    u8    unk35;
+    u8    unk36;
+    u8    unk37;
+    s16   unk38;
+    u8    pad3A[0x2];
+} B7DChanState;
 
-#pragma GLOBAL_ASM("asm/nonmatchings/init_1AAE0/__n_seqpStopOsc.s")
+typedef struct {
+    u8    pad0[0x34];
+    void (*unk34)(void *);
+    s32   unk38;
+} B7DBankCb;
+
+typedef struct {
+    u8            pad0[0x14];
+    B7DBankCb    *unk14;
+    u8            pad18[0x8];
+    ALBank       *unk20;
+    u8            pad24[0x3C];
+    B7DChanState *unk60;
+} B7DSeqp;
+
+s32 func_1001B7D0(B7DSeqp *arg0, s32 arg1, s32 arg2) {
+    ALSound *sp24;
+    ALInstrument *sp20;
+    s32 sp1C;
+
+    sp20 = (ALInstrument *)func_1001BD34(arg0->unk14, &arg0->unk20->instArray[arg1], -1);
+    if (arg0->unk60[arg2].unk0 != 0) {
+        arg0->unk14->unk34(arg0->unk20->instArray[arg0->unk60[arg2].unk38]);
+        arg0->unk60[arg2].unk0 = 0;
+    }
+    if (sp20 != 0) {
+        for (sp1C = 0; sp1C < sp20->soundCount; sp1C++) {
+            sp24 = sp20->soundArray[sp1C];
+            if ((u32) sp24->envelope < 0x100000) {
+                func_10012C5C(sp24, (s32) sp20, arg0->unk14->unk38);
+            }
+        }
+        sp24 = sp20->soundArray[0];
+    }
+    if (sp20 != 0) {
+        if (sp20->soundCount == 0) {
+            return 0;
+        }
+        if (sp24 != 0) {
+            arg0->unk60[arg2].unk1C = sp24->envelope->attackTime;
+            arg0->unk60[arg2].unk20 = sp24->envelope->decayTime;
+            arg0->unk60[arg2].unk24 = sp24->envelope->releaseTime;
+            arg0->unk60[arg2].unk29 = sp24->envelope->attackVolume;
+            arg0->unk60[arg2].unk2A = sp24->envelope->decayVolume;
+        }
+        arg0->unk60[arg2].unk6 = sp20->pan;
+        arg0->unk60[arg2].unk9 = sp20->volume;
+        arg0->unk60[arg2].unk7 = sp20->priority;
+        arg0->unk60[arg2].unk4 = sp20->bendRange;
+        arg0->unk60[arg2].unk2C = sp20->tremType;
+        arg0->unk60[arg2].unk2D = sp20->tremRate;
+        arg0->unk60[arg2].unk2E = sp20->tremDepth;
+        arg0->unk60[arg2].unk2F = sp20->tremDelay;
+        arg0->unk60[arg2].unk30 = sp20->vibType;
+        arg0->unk60[arg2].unk31 = sp20->vibRate;
+        arg0->unk60[arg2].unk32 = sp20->vibDepth;
+        arg0->unk60[arg2].unk33 = sp20->vibDelay;
+        arg0->unk60[arg2].unk36 = 0;
+        arg0->unk60[arg2].unk0 = sp20;
+    } else {
+        arg0->unk60[arg2].unk36 = 1;
+    }
+    arg0->unk60[arg2].unk2B = 0;
+    arg0->unk60[arg2].unk28 = 0;
+    arg0->unk60[arg2].unk35 = 0;
+    arg0->unk60[arg2].unk38 = arg1;
+    if (sp20 == 0) {
+        return 1;
+    }
+    return 0;
+}
+typedef s32 (*BankScanCb)(void *, s32);
+typedef BankScanCb (*BankScanGetter)(void);
+
+typedef struct {
+    u8             pad0[0x28];
+    BankScanGetter unk28;
+} BankScanObj;
+
+s32 func_1001BD34(BankScanObj *arg0, void **arg1, s32 arg2) {
+    BankScanCb sp1C;
+    s32 sp18;
+
+    sp18 = 0;
+    sp1C = arg0->unk28();
+    if (sp1C != 0) {
+        if (arg2 == -1) {
+            sp18 = sp1C(arg1, 1);
+        } else {
+            sp18 = sp1C((u8 *)*arg1 + arg2 * 4 + 0x10, 0);
+        }
+        if (sp18 != 0 && (sp18 & 0xFF000003) != 0x80000000) {
+            return 0;
+        }
+    } else {
+        return 0;
+    }
+    return sp18;
+}
+
+void func_1001BE1C(InitBankCallbacks *arg0, ALInstrument *inst, s32 idx) {
+    if (idx == -1) {
+        arg0->unk30(inst);
+    } else {
+        arg0->unk30(inst->soundArray[idx]);
+    }
+}
+
+typedef struct OscNode {
+    struct OscNode *unk0;
+    struct OscNode *unk4;
+    s32             unk8;
+    s16             unkC;
+    u8              padE[0x2];
+    void           *unk10;
+    void           *unk14;
+} OscNode;
+
+typedef struct {
+    u8       pad0[0x48];
+    OscNode *unk48;
+    u8       pad4C[0x4];
+    OscNode *unk50;
+    u8       pad54[0x24];
+    void   (*unk78)(void *);
+} OscSeqp;
+
+void __n_seqpStopOsc(OscSeqp *arg0, N_ALVoiceState *arg1) {
+    OscNode *sp2C;
+    OscNode *sp28;
+    s16 sp26;
+    OscNode *sp20;
+    OscNode *sp1C;
+    OscNode **sp18;
+
+    sp2C = arg0->unk50;
+    if (sp2C != 0) {
+        do {
+            sp28 = sp2C->unk0;
+            sp26 = sp2C->unkC;
+            if (sp26 == 0x17 || sp26 == 0x18) {
+                if (sp2C->unk10 == arg1) {
+                    arg0->unk78(sp2C->unk14);
+                    sp20 = sp2C;
+                    if (sp20->unk0 != 0) {
+                        sp20->unk0->unk4 = sp20->unk4;
+                    }
+                    if (sp20->unk4 != 0) {
+                        sp20->unk4->unk0 = sp20->unk0;
+                    }
+                    if (sp28 != 0) {
+                        sp28->unk8 += sp2C->unk8;
+                    }
+                    sp1C = sp2C;
+                    sp18 = &arg0->unk48;
+                    sp1C->unk0 = *sp18;
+                    sp1C->unk4 = (OscNode *)sp18;
+                    if (*sp18 != 0) {
+                        (*sp18)->unk4 = sp1C;
+                    }
+                    *sp18 = sp1C;
+                    if (sp26 == 0x17) {
+                        arg1->flags &= 0xFE;
+                    } else {
+                        arg1->flags &= 0xFD;
+                    }
+                    if (arg1->flags == 0) {
+                        return;
+                    }
+                }
+            }
+            sp2C = sp28;
+        } while (sp2C != 0);
+    }
+}

--- a/conker/src/init_1C060.c
+++ b/conker/src/init_1C060.c
@@ -28,180 +28,172 @@ void n_alEvtqNew(ALEventQueue *evtq, N_ALEventListItem *items, s32 itemCount)
 
 }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/init_1C060/n_alEvtqNextEvent.s")
-// s32 n_alEvtqNextEvent(void *arg0, void *arg1) {
-//     void *sp2C;
-//     s32 sp28;
-//     void *sp24;
-//     void *sp20;
-//     void *sp1C;
-//
-//     sp2C = arg0->unk8;
-//     if (sp2C != 0) {
-//         sp24 = sp2C;
-//         if (sp24->unk0 != 0) {
-//             sp24->unk0->unk4 = (s32) sp24->unk4;
-//         }
-//         if (sp24->unk4 != 0) {
-//             *sp24->unk4 = (s32) sp24->unk0;
-//         }
-//         bcopy(sp2C + 0xC, arg1, 0x10);
-//         sp20 = sp2C;
-//         sp1C = arg0;
-//         sp20->unk0 = (s32) *sp1C;
-//         sp20->unk4 = sp1C;
-//         if (*sp1C != 0) {
-//             (*sp1C)->unk4 = sp20;
-//         }
-//         *sp1C = sp20;
-//         sp28 = sp2C->unk8;
-//     } else {
-//         *arg1 = (u16)-1;
-//         sp28 = 0;
-//     }
-//     return sp28;
-// }
+ALMicroTime n_alEvtqNextEvent(ALEventQueue *evtq, N_ALEvent *event)
+{
+    N_ALEventListItem *item;
+    ALMicroTime delta;
+    ALLink *element;
+    ALLink *element2;
+    ALLink *after;
 
-#pragma GLOBAL_ASM("asm/nonmatchings/init_1C060/n_alEvtqPostEvent.s")
-// void n_alEvtqPostEvent(void *arg0, s32 arg1, s32 arg2, s32 arg3) {
-//     void *sp3C;
-//     void *sp38;
-//     void *sp34;
-//     s32 sp30;
-//     s32 sp2C;
-//     void *sp28;
-//     void *sp24;
-//     void *sp20;
-//     void *sp1C;
-//     void *sp18;
-//     void *temp_t3;
-//     void *temp_t5;
-//
-//     sp30 = 0;
-//     if ((arg3 & 2) != 0) {
-//         sp2C = osSetIntMask(1);
-//     }
-//     sp3C = *arg0;
-//     if (sp3C == 0) {
-//         if ((arg3 & 2) != 0) {
-//             osSetIntMask(sp2C);
-//         }
-//         return;
-//     }
-//     if ((sp3C->unk0 == 0) && ((arg3 & 1) == 0)) {
-//         if ((arg3 & 2) != 0) {
-//             osSetIntMask(sp2C);
-//         }
-//         return;
-//     }
-//     sp28 = sp3C;
-//     if (sp28->unk0 != 0) {
-//         sp28->unk0->unk4 = (s32) sp28->unk4;
-//     }
-//     if (sp28->unk4 != 0) {
-//         *sp28->unk4 = (s32) sp28->unk0;
-//     }
-//     bcopy(arg1, sp3C + 0xC, 0x10);
-//     if (arg2 == 0x7FFFFFFF) {
-//         sp30 = -1;
-//     }
-//     temp_t3 = arg0 + 8;
-//     sp34 = temp_t3;
-//     if (temp_t3 != 0) {
-// loop_18:
-//         if (*sp34 == 0) {
-//             if (sp30 != 0) {
-//                 sp3C->unk8 = 0;
-//             } else {
-//                 sp3C->unk8 = arg2;
-//             }
-//             sp24 = sp3C;
-//             sp20 = sp34;
-//             sp24->unk0 = (s32) *sp20;
-//             sp24->unk4 = sp20;
-//             if (*sp20 != 0) {
-//                 (*sp20)->unk4 = sp24;
-//             }
-//             *sp20 = sp24;
-//         } else {
-//             sp38 = *sp34;
-//             if (arg2 < sp38->unk8) {
-//                 sp3C->unk8 = arg2;
-//                 sp38->unk8 = (s32) (sp38->unk8 - arg2);
-//                 sp1C = sp3C;
-//                 sp18 = sp34;
-//                 sp1C->unk0 = (s32) *sp18;
-//                 sp1C->unk4 = sp18;
-//                 if (*sp18 != 0) {
-//                     (*sp18)->unk4 = sp1C;
-//                 }
-//                 *sp18 = sp1C;
-//             } else {
-//                 arg2 = arg2 - sp38->unk8;
-//                 temp_t5 = *sp34;
-//                 sp34 = temp_t5;
-//                 if (temp_t5 != 0) {
-//                     goto loop_18;
-//                 }
-//             }
-//         }
-//     }
-//     if ((arg3 & 2) != 0) {
-//         osSetIntMask(sp2C);
-//     }
-// }
+    item = (N_ALEventListItem *)evtq->allocList.next;
+    if (item) {
+        element = (ALLink *)item;
+        if (element->next) {
+            element->next->prev = element->prev;
+        }
+        if (element->prev) {
+            element->prev->next = element->next;
+        }
+        bcopy(&item->evt, event, 0x10);
+        element2 = (ALLink *)item;
+        after = &evtq->freeList;
+        element2->next = after->next;
+        element2->prev = after;
+        if (after->next) {
+            after->next->prev = element2;
+        }
+        after->next = element2;
+        delta = item->delta;
+    } else {
+        event->type = -1;
+        delta = 0;
+    }
+    return delta;
+}
 
-#pragma GLOBAL_ASM("asm/nonmatchings/init_1C060/func_1001C4F0.s")
-// s32 func_1001C4F0(void *arg0, s16 arg1) {
-//     void *sp3C;
-//     void *sp38;
-//     void *sp34;
-//     void *sp30;
-//     s32 sp2C;
-//     s32 sp28;
-//     s32 sp24;
-//     void *sp20;
-//     void *sp1C;
-//     void *sp18;
-//
-//     sp28 = 0;
-//     sp24 = 0;
-//     sp2C = osSetIntMask(1);
-//     sp3C = arg0->unk8;
-//     if (sp3C != 0) {
-// loop_1:
-//         sp38 = *sp3C;
-//         sp34 = sp3C;
-//         sp30 = sp38;
-//         sp24 = sp24 + sp34->unk8;
-//         if (sp34->unkC == arg1) {
-//             if (sp28 == 0) {
-//                 sp28 = sp24;
-//             }
-//             if (sp30 != 0) {
-//                 sp30->unk8 = (s32) (sp30->unk8 + sp34->unk8);
-//             }
-//             sp20 = sp3C;
-//             if (sp20->unk0 != 0) {
-//                 sp20->unk0->unk4 = (s32) sp20->unk4;
-//             }
-//             if (sp20->unk4 != 0) {
-//                 *sp20->unk4 = (s32) sp20->unk0;
-//             }
-//             sp1C = sp3C;
-//             sp18 = arg0;
-//             sp1C->unk0 = (s32) *sp18;
-//             sp1C->unk4 = sp18;
-//             if (*sp18 != 0) {
-//                 (*sp18)->unk4 = sp1C;
-//             }
-//             *sp18 = sp1C;
-//         }
-//         sp3C = sp38;
-//         if (sp3C != 0) {
-//             goto loop_1;
-//         }
-//     }
-//     osSetIntMask(sp2C);
-//     return sp28;
-// }
+
+void n_alEvtqPostEvent(ALEventQueue *evtq, N_ALEvent *event, ALMicroTime delta, s32 flags)
+{
+    N_ALEventListItem *item;
+    N_ALEventListItem *thisItem;
+    ALLink *nextItem;
+    s32 atEnd;
+    OSIntMask savedMask;
+    ALLink *unlinkEl;
+    ALLink *elA;
+    ALLink *afterA;
+    ALLink *elB;
+    ALLink *afterB;
+
+    atEnd = 0;
+    if (flags & 2) {
+        savedMask = osSetIntMask(1);
+    }
+    item = (N_ALEventListItem *)evtq->freeList.next;
+    if (item == 0) {
+        if (flags & 2) {
+            osSetIntMask(savedMask);
+        }
+        return;
+    }
+    if (item->node.next == 0 && (flags & 1) == 0) {
+        if (flags & 2) {
+            osSetIntMask(savedMask);
+        }
+        return;
+    }
+    unlinkEl = (ALLink *)item;
+    if (unlinkEl->next) {
+        unlinkEl->next->prev = unlinkEl->prev;
+    }
+    if (unlinkEl->prev) {
+        unlinkEl->prev->next = unlinkEl->next;
+    }
+    bcopy(event, &item->evt, 0x10);
+    if (delta == 0x7FFFFFFF) {
+        atEnd = -1;
+    }
+    for (nextItem = &evtq->allocList; nextItem; nextItem = nextItem->next) {
+        if (nextItem->next == 0) {
+            if (atEnd) {
+                item->delta = 0;
+            } else {
+                item->delta = delta;
+            }
+            elA = (ALLink *)item;
+            afterA = nextItem;
+            elA->next = afterA->next;
+            elA->prev = afterA;
+            if (afterA->next) {
+                afterA->next->prev = elA;
+            }
+            afterA->next = elA;
+            break;
+        } else {
+            thisItem = (N_ALEventListItem *)nextItem->next;
+            if (delta < thisItem->delta) {
+                item->delta = delta;
+                thisItem->delta = thisItem->delta - delta;
+                elB = (ALLink *)item;
+                afterB = nextItem;
+                elB->next = afterB->next;
+                elB->prev = afterB;
+                if (afterB->next) {
+                    afterB->next->prev = elB;
+                }
+                afterB->next = elB;
+                break;
+            }
+            delta = delta - thisItem->delta;
+        }
+    }
+    if (flags & 2) {
+        osSetIntMask(savedMask);
+    }
+}
+
+
+s32 func_1001C4F0(ALEventQueue *evtq, s16 type)
+{
+    N_ALEventListItem *item;
+    N_ALEventListItem *next;
+    N_ALEventListItem *el;
+    N_ALEventListItem *nextCopy;
+    OSIntMask savedMask;
+    s32 firstDelta;
+    s32 cumDelta;
+    ALLink *unlinkEl;
+    ALLink *linkEl;
+    ALLink *after;
+
+    firstDelta = 0;
+    cumDelta = 0;
+    savedMask = osSetIntMask(1);
+    item = (N_ALEventListItem *)evtq->allocList.next;
+    if (item) {
+        do {
+            next = (N_ALEventListItem *)item->node.next;
+            el = item;
+            nextCopy = next;
+            cumDelta += el->delta;
+            if (el->evt.type == type) {
+                if (firstDelta == 0) {
+                    firstDelta = cumDelta;
+                }
+                if (nextCopy) {
+                    nextCopy->delta = nextCopy->delta + el->delta;
+                }
+                unlinkEl = (ALLink *)item;
+                if (unlinkEl->next) {
+                    unlinkEl->next->prev = unlinkEl->prev;
+                }
+                if (unlinkEl->prev) {
+                    unlinkEl->prev->next = unlinkEl->next;
+                }
+                linkEl = (ALLink *)item;
+                after = &evtq->freeList;
+                linkEl->next = after->next;
+                linkEl->prev = after;
+                if (after->next) {
+                    after->next->prev = linkEl;
+                }
+                after->next = linkEl;
+            }
+            item = next;
+        } while (item);
+    }
+    osSetIntMask(savedMask);
+    return firstDelta;
+}
+

--- a/conker/src/init_1E530.c
+++ b/conker/src/init_1E530.c
@@ -3,118 +3,192 @@
 #include "functions.h"
 #include "variables.h"
 
+// File-local 8-byte audio command (w0/w1). struct56 in structs.h is 12 bytes
+// (self-pointer unk8), but this file advances by 8 bytes per command.
+typedef struct {
+    /* 0x0 */ s32 unk0;
+    /* 0x4 */ s32 unk4;
+} A8;
+
+// File-local view of struct55 with an inline unk2C[] array (structs.h declares
+// it as a pointer, but the asm uses a single-load array access).
+typedef struct {
+    /* 0x00 */ s16 unk0;
+    /* 0x02 */ s16 unk2;
+    /* 0x04 */ s32 unk4;
+    /* 0x08 */ s32 unk8;
+    /* 0x0C */ u8 pad[0x1C];
+    /* 0x28 */ s32 unk28;
+    /* 0x2C */ void *unk2C[1];
+} A55;
+
+// arg0 to the buffer-loader helpers: unk0 count at 0x0, inline unk20[]/unk28[] arrays.
+typedef struct {
+    /* 0x00 */ s32 unk0;
+    /* 0x04 */ u8 pad[0x1C];
+    /* 0x20 */ s32 unk20[2];
+    /* 0x28 */ s32 unk28[1];
+} A20;
+
+// arg1->unk24 target: inline unk14[] address array, f32 unk24, s32 unk28.
+typedef struct {
+    /* 0x00 */ u8 pad0[0x14];
+    /* 0x14 */ void *unk14[4];
+    /* 0x24 */ f32 unk24;
+    /* 0x28 */ s32 unk28;
+} A24;
+
+// arg1 to func_1001F28C (also passed to func_1001FA78 as a matrix).
+typedef struct {
+    /* 0x00 */ s32 unk0;
+    /* 0x04 */ s32 unk4;
+    /* 0x08 */ u8 pad8[0x10];
+    /* 0x18 */ s32 unk18;
+    /* 0x1C */ u8 pad1C[0x8];
+    /* 0x24 */ A24 *unk24;
+    /* 0x28 */ s32 unk28;
+} A_arg1;
+
+A8 *func_1001F5A4(A20 *arg0, s32 arg1, u32 arg2, s32 arg3, s32 arg4, A8 *arg5);
+
 
 #pragma GLOBAL_ASM("asm/nonmatchings/init_1E530/func_1001E530.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/init_1E530/func_1001ED6C.s")
 // _n_loadOutputBuffer ?
-#pragma GLOBAL_ASM("asm/nonmatchings/init_1E530/func_1001F28C.s")
 // _n_loadBuffer ?
-#pragma GLOBAL_ASM("asm/nonmatchings/init_1E530/func_1001F5A4.s")
-// void *func_1001F5A4(void *arg0, s32 arg1, u32 arg2, s32 arg3, s32 arg4, void *arg5) {
-//     void *sp34;
-//     s32 sp30;
-//     s32 sp2C;
-//     u32 sp28;
-//     u32 sp24;
-//     void *sp20;
-//     void *sp1C;
-//     void *sp18;
-//     void *temp_t3;
-//     void *temp_t3_2;
-//     void *temp_t7;
-//
-//     sp34 = arg5;
-//     sp24 = (arg0 + (arg1 * 4))->unk20 + (*arg0 * 2);
-//     if (arg2 < (u32) (arg0 + (arg1 * 4))->unk20) {
-//         arg2 = arg2 + (*arg0 * 2);
-//     }
-//     sp28 = (arg4 * 2) + arg2;
-//     if (sp24 < sp28) {
-//         sp30 = (s32) (sp28 - sp24) >> 1;
-//         sp2C = (s32) (sp24 - arg2) >> 1;
-//         temp_t7 = sp34;
-//         sp34 = temp_t7 + 8;
-//         sp20 = temp_t7;
-//         *temp_t7 = (s32) ((((sp2C * 2) & 0xFFF) << 0xC) | 0x4000000 | (arg3 & 0xFFF));
-//         sp20->unk4 = osVirtualToPhysical(arg2);
-//         temp_t3 = sp34;
-//         sp34 = temp_t3 + 8;
-//         sp1C = temp_t3;
-//         sp1C->unk0 = (s32) ((((sp30 * 2) & 0xFFF) << 0xC) | 0x4000000 | ((arg3 + (sp2C * 2)) & 0xFFF));
-//         sp1C->unk4 = osVirtualToPhysical((arg0 + (arg1 * 4))->unk20);
-//     } else {
-//         temp_t3_2 = sp34;
-//         sp34 = temp_t3_2 + 8;
-//         sp18 = temp_t3_2;
-//         *temp_t3_2 = (s32) ((((arg4 * 2) & 0xFFF) << 0xC) | 0x4000000 | (arg3 & 0xFFF));
-//         sp18->unk4 = osVirtualToPhysical(arg2);
-//     }
-//     return sp34;
-// }
+A8 *func_1001F28C(A20 *arg0, A_arg1 *arg1, s32 arg2, s32 arg3, A8 *arg4) {
+    A8 *local54;
+    s32 local50;
+    s32 local4C;
+    s32 local48;
+    s32 local44;
+    f32 local40;
+    f32 local3C;
+    f32 local38;
+    s32 local34;
+    s32 local30;
+    s32 local2C;
+    s16 local2A;
+    A8 *local24;
 
-#pragma GLOBAL_ASM("asm/nonmatchings/init_1E530/func_1001F79C.s")
-// void *func_1001F79C(void *arg0, s32 arg1, u32 arg2, s32 arg3, void *arg4) {
-//     void *sp34;
-//     s32 sp30;
-//     s32 sp2C;
-//     u32 sp28;
-//     u32 sp24;
-//     void *sp20;
-//     void *sp1C;
-//     void *sp18;
-//     void *temp_t0;
-//     void *temp_t7;
-//     void *temp_t7_2;
-//
-//     sp34 = arg4;
-//     sp24 = (arg0 + (arg1 * 4))->unk20 + (*arg0 * 2);
-//     if (arg2 < (u32) (arg0 + (arg1 * 4))->unk20) {
-//         arg2 = arg2 + (*arg0 * 2);
-//     }
-//     sp28 = arg2 + 0x170;
-//     if (sp24 < sp28) {
-//         sp30 = (s32) (sp28 - sp24) >> 1;
-//         sp2C = (s32) (sp24 - arg2) >> 1;
-//         temp_t0 = sp34;
-//         sp34 = temp_t0 + 8;
-//         sp20 = temp_t0;
-//         *temp_t0 = (s32) ((((sp2C * 2) & 0xFFF) << 0xC) | 0x6000000 | (arg3 & 0xFFF));
-//         sp20->unk4 = osVirtualToPhysical(arg2);
-//         temp_t7 = sp34;
-//         sp34 = temp_t7 + 8;
-//         sp1C = temp_t7;
-//         sp1C->unk0 = (s32) ((((sp30 * 2) & 0xFFF) << 0xC) | 0x6000000 | ((arg3 + (sp2C * 2)) & 0xFFF));
-//         sp1C->unk4 = osVirtualToPhysical((arg0 + (arg1 * 4))->unk20);
-//     } else {
-//         temp_t7_2 = sp34;
-//         sp34 = temp_t7_2 + 8;
-//         sp18 = temp_t7_2;
-//         sp18->unk0 = (s32) ((arg3 & 0xFFF) | 0x6170000);
-//         sp18->unk4 = osVirtualToPhysical(arg2);
-//     }
-//     return sp34;
-// }
+    local54 = arg4;
+    local48 = 0x2E0;
+    local34 = 0;
+    local2C = 0xB8;
+    if (arg1->unk24 != 0) {
+        local30 = arg1->unk4 - arg1->unk0;
+        local38 = func_1001FA78((f32 (*)[4]) arg1, local2C);
+        local38 = local38 / (f32) local30;
+        local38 = (f32) (s32) (local38 * 32768.0f);
+        local38 = local38 / 32768.0f;
+        local3C = 1.0f - local38;
+        local40 = arg1->unk24->unk24 + (local3C * (f32) local2C);
+        local4C = (s32) local40;
+        arg1->unk24->unk24 = local40 - (f32) local4C;
+        local44 = arg0->unk28[arg2] + (-(arg1->unk4 - arg1->unk18)) * 2;
+        local34 = (local44 & 7) >> 1;
+        local54 = func_1001F5A4(arg0, arg2, local44 - (local34 * 2), local48, local4C + local34, local54);
+        local50 = (s32) (local3C * 32768.0f);
+        local2A = arg3 >> 8;
+        local24 = local54++;
+        local24->unk0 = (osVirtualToPhysical(arg1->unk24->unk14[arg2]) & 0xFFFFFF) | 0x5000000;
+        local24->unk4 = ((arg1->unk24->unk28 & 3) << 30) | ((local50 & 0xFFFF) << 0xE) | (((local48 + (local34 * 2)) & 0xFFF) << 2) | (local2A & 3);
+        arg1->unk24->unk28 = 0;
+        arg1->unk18 = arg1->unk18 + (local4C - local2C);
+    } else {
+        local44 = arg0->unk28[arg2] + (-arg1->unk4) * 2;
+        local54 = func_1001F5A4(arg0, arg2, local44, arg3, 0xB8, local54);
+    }
+    return local54;
+}
 
-#pragma GLOBAL_ASM("asm/nonmatchings/init_1E530/func_1001F978.s")
-// NON-MATCHING: lots of work still to do
-// struct56 *func_1001F978(struct55 *arg0, s32 arg1, s32 arg2, struct56 *arg3) {
-//     struct56 *sp24;
-//     s16 sp22;
-//     struct56 *temp_t9;
-//
-//     sp24 = arg3;
-//     sp22 = arg2 >> 8;
-//     temp_t9 = sp24;
-//     sp24 = temp_t9->unk8;
-//     temp_t9->unk0 = 0xB000020;
-//     temp_t9->unk4 = osVirtualToPhysical(&arg0->unk8);
-//     temp_t9 = sp24;
-//     sp24 = temp_t9->unk8;
-//     temp_t9->unk0 = (s32) (((arg0->unk28 & 0xFF) << 0x10) | 0xE000000 | (arg0->unk2 & 0xFFFF));
-//     temp_t9->unk4 = (s32) ((osVirtualToPhysical(arg0->unk2C[arg1]) & 0xFFFFFF) | ((sp22 & 0xFF) << 0x18));
-//     arg0->unk28 = 0;
-//     return sp24;
-// }
+A8 *func_1001F5A4(A20 *arg0, s32 arg1, u32 arg2, s32 arg3, s32 arg4, A8 *arg5) {
+    A8 *sp34;
+    s32 sp30;
+    s32 sp2C;
+    u32 sp28;
+    u32 sp24;
+    A8 *sp20;
+    A8 *sp1C;
+    A8 *sp18;
+
+    sp34 = arg5;
+    sp24 = arg0->unk20[arg1] + (arg0->unk0 * 2);
+    if (arg2 < (u32) arg0->unk20[arg1]) {
+        arg2 += arg0->unk0 * 2;
+    }
+    sp28 = (arg4 * 2) + arg2;
+    if (sp28 > sp24) {
+        sp30 = (s32) (sp28 - sp24) >> 1;
+        sp2C = (s32) (sp24 - arg2) >> 1;
+        sp20 = sp34++;
+        sp20->unk0 = (((sp2C * 2) & 0xFFF) << 0xC) | 0x4000000 | (arg3 & 0xFFF);
+        sp20->unk4 = osVirtualToPhysical((void *) arg2);
+        sp1C = sp34++;
+        sp1C->unk0 = (((sp30 * 2) & 0xFFF) << 0xC) | 0x4000000 | ((arg3 + (sp2C * 2)) & 0xFFF);
+        sp1C->unk4 = osVirtualToPhysical((void *) arg0->unk20[arg1]);
+        arg0 = arg0;
+    } else {
+        sp18 = sp34++;
+        sp18->unk0 = (((arg4 * 2) & 0xFFF) << 0xC) | 0x4000000 | (arg3 & 0xFFF);
+        sp18->unk4 = osVirtualToPhysical((void *) arg2);
+    }
+    return sp34;
+}
+
+A8 *func_1001F79C(A20 *arg0, s32 arg1, u32 arg2, s32 arg3, A8 *arg4) {
+    A8 *sp34;
+    s32 sp30;
+    s32 sp2C;
+    u32 sp28;
+    u32 sp24;
+    A8 *sp20;
+    A8 *sp1C;
+    A8 *sp18;
+
+    sp34 = arg4;
+    sp24 = arg0->unk20[arg1] + (arg0->unk0 * 2);
+    if (arg2 < (u32) arg0->unk20[arg1]) {
+        arg2 += arg0->unk0 * 2;
+    }
+    sp28 = arg2 + 0x170;
+    if (sp28 > sp24) {
+        sp30 = (s32) (sp28 - sp24) >> 1;
+        sp2C = (s32) (sp24 - arg2) >> 1;
+        sp20 = sp34++;
+        sp20->unk0 = (((sp2C * 2) & 0xFFF) << 0xC) | 0x6000000 | (arg3 & 0xFFF);
+        sp20->unk4 = osVirtualToPhysical((void *) arg2);
+        sp1C = sp34++;
+        sp1C->unk0 = (((sp30 * 2) & 0xFFF) << 0xC) | 0x6000000 | ((arg3 + (sp2C * 2)) & 0xFFF);
+        sp1C->unk4 = osVirtualToPhysical((void *) arg0->unk20[arg1]);
+        arg0 = arg0;
+    } else {
+        sp18 = sp34++;
+        sp18->unk0 = (arg3 & 0xFFF) | 0x6170000;
+        sp18->unk4 = osVirtualToPhysical((void *) arg2);
+    }
+    return sp34;
+}
+
+A8 *func_1001F978(A55 *arg0, s32 arg1, s32 arg2, A8 *arg3) {
+    A8 *sp24;
+    s16 sp22;
+    A8 *sp1C;
+    A8 *sp18;
+
+    sp24 = arg3;
+    sp22 = arg2 >> 8;
+
+    sp1C = sp24++;
+    sp1C->unk0 = 0xB000020;
+    sp1C->unk4 = osVirtualToPhysical(&arg0->unk8);
+
+    sp18 = sp24++;
+    sp18->unk0 = ((arg0->unk28 & 0xFF) << 0x10) | 0xE000000 | (arg0->unk2 & 0xFFFF);
+    sp18->unk4 = (osVirtualToPhysical(arg0->unk2C[arg1]) & 0xFFFFFF) | ((sp22 & 0xFF) << 0x18);
+    arg0->unk28 = 0;
+    return sp24;
+}
 
 f32 func_1001FA78(f32 arg0[4][4], s32 arg1) {
     f32 tmp;

--- a/conker/src/init_1FB40.c
+++ b/conker/src/init_1FB40.c
@@ -1,139 +1,132 @@
 #include <n_libaudio.h>
 
+extern s32 D_800E0E04;
+extern u8 D_800428C4[];
+extern u8 D_800428C6[];
 
-#pragma GLOBAL_ASM("asm/nonmatchings/init_1FB40/func_1001FB40.s")
-// void *func_1001FB40(s32 arg0, void *arg1) {
-//     void *sp54;
-//     s32 sp50;
-//     s32 sp4C;
-//     void *sp48;
-//     void *sp44;
-//     void *sp40;
-//     void *sp3C;
-//     void *sp38;
-//     void *sp34;
-//     void *sp30;
-//     void *sp2C;
-//     void *sp28;
-//     void *sp24;
-//     void *sp20;
-//     void *sp1C;
-//     s32 temp_t2;
-//     s32 temp_t6_2;
-//     void *temp_t0;
-//     void *temp_t0_2;
-//     void *temp_t1;
-//     void *temp_t2_2;
-//     void *temp_t4;
-//     void *temp_t5;
-//     void *temp_t5_2;
-//     void *temp_t6;
-//     void *temp_t7;
-//     void *temp_t8;
-//     void *temp_t8_2;
-//
-//     sp54 = arg1;
-//     if ((D_800E0E04 == 0) || (func_151F2E88(0xB8, &sp54) == 0)) {
-//         temp_t8 = sp54;
-//         sp54 = temp_t8 + 8;
-//         sp48 = temp_t8;
-//         sp48->unk0 = 0x20004E0;
-//         sp48->unk4 = 0x2E0;
-//         temp_t4 = sp54;
-//         sp54 = temp_t4 + 8;
-//         sp44 = temp_t4;
-//         sp44->unk0 = 0x20007C0;
-//         sp44->unk4 = 0x2E0;
-//     }
-//     sp4C = 0;
-//     sp50 = 1;
-//     if (D_8002BA44->unk50 >= 2) {
-// loop_4:
-//         if ((s32) (D_8002BA44->unk48 + (sp50 * 0x44))->unk40->unk2 > 0) {
-//             sp4C = sp50;
-//         }
-//         temp_t2 = sp50 + 1;
-//         sp50 = temp_t2;
-//         if (temp_t2 < D_8002BA44->unk50) {
-//             goto loop_4;
-//         }
-//     }
-//     sp50 = 0;
-//     if (D_8002BA44->unk50 > 0) {
-// loop_8:
-//         if (sp4C >= D_8002BA44->unk50) {
-//             sp4C = 0;
-//         }
-//         if (sp50 != 0) {
-//             temp_t1 = sp54;
-//             sp54 = temp_t1 + 8;
-//             sp40 = temp_t1;
-//             sp40->unk0 = 0x20007C0;
-//             sp40->unk4 = 0x2E0;
-//         }
-//         sp54 = D_8002BA44->unk44->unk4(arg0, sp54, sp4C);
-//         if (*(&D_800428C4 + sp4C) != 0) {
-//             if (*(&D_800428C6 + sp4C) != 0) {
-//                 temp_t5 = sp54;
-//                 sp54 = temp_t5 + 8;
-//                 sp3C = temp_t5;
-//                 sp3C->unk0 = 0xC008000;
-//                 sp3C->unk4 = 0x7C004E0;
-//             } else {
-//                 temp_t0 = sp54;
-//                 sp54 = temp_t0 + 8;
-//                 sp38 = temp_t0;
-//                 sp38->unk0 = 0xC007FFF;
-//                 sp38->unk4 = 0x7C00650;
-//             }
-//         } else {
-//             if (*(&D_800428C6 + sp4C) != 0) {
-//                 temp_t7 = sp54;
-//                 sp54 = temp_t7 + 8;
-//                 sp34 = temp_t7;
-//                 sp34->unk0 = 0xC008000;
-//                 sp34->unk4 = 0x7C00650;
-//             } else {
-//                 temp_t5_2 = sp54;
-//                 sp54 = temp_t5_2 + 8;
-//                 sp30 = temp_t5_2;
-//                 sp30->unk0 = 0xC007FFF;
-//                 sp30->unk4 = 0x7C00650;
-//             }
-//             temp_t0_2 = sp54;
-//             sp54 = temp_t0_2 + 8;
-//             sp2C = temp_t0_2;
-//             sp2C->unk0 = 0xC007FFF;
-//             sp2C->unk4 = 0x7C004E0;
-//         }
-//         if ((s32) D_8002BA44->unk48[sp4C]->unk40->unk2 > 0) {
-//             sp28 = D_8002BA44->unk48[sp4C]->unk40;
-//             if (sp28->unk28 != 0) {
-//                 func_1001CF38(sp28, (f32) D_8002BA44->unk54);
-//             }
-//             temp_t2_2 = sp54;
-//             sp54 = temp_t2_2 + 8;
-//             sp24 = temp_t2_2;
-//             sp24->unk0 = 0xB000020;
-//             sp24->unk4 = osVirtualToPhysical(sp28 + 8);
-//             temp_t8_2 = sp54;
-//             sp54 = temp_t8_2 + 8;
-//             sp20 = temp_t8_2;
-//             sp20->unk0 = 0xE0004E0;
-//             sp20->unk4 = (s32) (osVirtualToPhysical(sp28->unk2C) & 0xFFFFFF & 0xFFFFFF);
-//             temp_t6 = sp54;
-//             sp54 = temp_t6 + 8;
-//             sp1C = temp_t6;
-//             sp1C->unk0 = 0xE000650;
-//             sp1C->unk4 = (s32) (osVirtualToPhysical(sp28->unk30) & 0xFFFFFF & 0xFFFFFF);
-//             sp28->unk28 = 0;
-//         }
-//         temp_t6_2 = sp50 + 1;
-//         sp4C = sp4C + 1;
-//         sp50 = temp_t6_2;
-//         if (temp_t6_2 < D_8002BA44->unk50) {
-//             goto loop_8;
-//         }
-//     }
-//     return sp54;
-// }
+typedef struct { u32 w0; u32 w1; } Cmd;
+
+typedef struct {
+    u8  pad0[0x2];
+    /* 0x2 */  s16   unk2;
+    u8  pad4[0x4];
+    /* 0x8 */  s32   unk8;
+    u8  padC[0x1C];
+    /* 0x28 */ s32   unk28;
+    /* 0x2C */ void *unk2C;
+    /* 0x30 */ void *unk30;
+} Filter;
+
+typedef struct {
+    u8  pad0[0x40];
+    /* 0x40 */ Filter *unk40;
+} AuxEntry;
+
+typedef Cmd *(*Handler)(s32, Cmd *, s32);
+
+typedef struct {
+    u8  pad0[0x4];
+    /* 0x4 */ Handler unk4;
+} MainBus;
+
+typedef struct {
+    u8  pad0[0x44];
+    /* 0x44 */ MainBus  *unk44;
+    /* 0x48 */ AuxEntry *unk48;
+    u8  pad4C[0x4];
+    /* 0x50 */ s32       unk50;
+    /* 0x54 */ s32       unk54;
+} Synth;
+
+void func_1001CF38(void *, f32);
+
+#define S ((Synth *) n_syn)
+
+Cmd *func_1001FB40(s32 arg0, Cmd *arg1) {
+    Cmd *sp54;
+    s32  sp50;
+    s32  sp4C;
+    Cmd *sp48;
+    Cmd *sp44;
+    Cmd *sp40;
+    Cmd *sp3C;
+    Cmd *sp38;
+    Cmd *sp34;
+    Cmd *sp30;
+    Cmd *sp2C;
+    Filter *sp28;
+    Cmd *sp24;
+    Cmd *sp20;
+    Cmd *sp1C;
+
+    sp54 = arg1;
+    if ((D_800E0E04 == 0) || (func_151F2E88(0xB8, &sp54) == 0)) {
+        sp48 = sp54++;
+        sp48->w0 = 0x20004E0;
+        sp48->w1 = 0x2E0;
+        sp44 = sp54++;
+        sp44->w0 = 0x20007C0;
+        sp44->w1 = 0x2E0;
+    }
+    sp4C = 0;
+    for (sp50 = 1; sp50 < S->unk50; sp50++) {
+        if (S->unk48[sp50].unk40->unk2 > 0) {
+            sp4C = sp50;
+        }
+    }
+    for (sp50 = 0; sp50 < S->unk50; sp50++, sp4C++) {
+        if (sp4C >= S->unk50) {
+            sp4C = 0;
+        }
+        if (sp50 != 0) {
+            sp40 = sp54++;
+            sp40->w0 = 0x20007C0;
+            sp40->w1 = 0x2E0;
+        }
+        sp54 = S->unk44->unk4(arg0, sp54, sp4C);
+        if (D_800428C4[sp4C] != 0) {
+            if (D_800428C6[sp4C] != 0) {
+                sp3C = sp54++;
+                sp3C->w0 = 0xC008000;
+                sp3C->w1 = 0x7C004E0;
+                goto block1;
+            }
+            sp38 = sp54++;
+            sp38->w0 = 0xC007FFF;
+            sp38->w1 = 0x7C00650;
+        block1:
+            ;
+        } else {
+            if (D_800428C6[sp4C] != 0) {
+                sp34 = sp54++;
+                sp34->w0 = 0xC008000;
+                sp34->w1 = 0x7C00650;
+                goto block2;
+            }
+            sp30 = sp54++;
+            sp30->w0 = 0xC007FFF;
+            sp30->w1 = 0x7C00650;
+        block2:
+            sp2C = sp54++;
+            sp2C->w0 = 0xC007FFF;
+            sp2C->w1 = 0x7C004E0;
+        }
+        if (S->unk48[sp4C].unk40->unk2 > 0) {
+            sp28 = S->unk48[sp4C].unk40;
+            if (sp28->unk28 != 0) {
+                func_1001CF38(sp28, (f32) S->unk54);
+            }
+            sp24 = sp54++;
+            sp24->w0 = 0xB000020;
+            sp24->w1 = osVirtualToPhysical(&sp28->unk8);
+            sp20 = sp54++;
+            sp20->w0 = 0xE0004E0;
+            sp20->w1 = osVirtualToPhysical(sp28->unk2C) & 0xFFFFFF & 0xFFFFFF;
+            sp1C = sp54++;
+            sp1C->w0 = 0xE000650;
+            sp1C->w1 = osVirtualToPhysical(sp28->unk30) & 0xFFFFFF & 0xFFFFFF;
+            sp28->unk28 = 0;
+        }
+    }
+    return sp54;
+}

--- a/conker/src/init_20000.c
+++ b/conker/src/init_20000.c
@@ -41,66 +41,100 @@ s32 n_alEnvmixerParam(N_PVoice *filter, s32 paramID, void *param) {
   return 0;
 }
 
+extern s16 D_8002BC10[];
+extern s16 D_8002BD0E[];
+
+typedef struct { u32 w0; u32 w1; } Cmd;
+
+typedef struct {
+    u8  pad0[0xA];
+    /* 0xA */ u8 unkA;
+} SubState;
+
+typedef struct {
+    u8  pad0[0x28];
+    /* 0x28 */ SubState *unk28;
+    u8  pad2C[0x30];
+    /* 0x5C */ void *unk5C;
+    /* 0x60 */ s16  unk60;
+    /* 0x62 */ s16  unk62;
+    /* 0x64 */ s16  unk64;
+    /* 0x66 */ s16  unk66;
+    /* 0x68 */ s16  unk68;
+    /* 0x6A */ s16  unk6A;
+    /* 0x6C */ u16  unk6C;
+    /* 0x6E */ s16  unk6E;
+    /* 0x70 */ s16  unk70;
+    /* 0x72 */ u16  unk72;
+    /* 0x74 */ s16  unk74;
+    /* 0x76 */ s16  unk76;
+    /* 0x78 */ s32  unk78;
+    /* 0x7C */ s32  unk7C;
+    /* 0x80 */ s32  unk80;
+    u8  pad84[0x8];
+    /* 0x8C */ s32  unk8C;
+} SubVoice;
+
+s16 _getRate(f32, f32, s32, u16 *);
+Cmd *func_10022040(SubVoice *, s16 *, s32, Cmd *);
+
 // _pullSubFrame
-#pragma GLOBAL_ASM("asm/nonmatchings/init_20000/func_10020ABC.s")
-// NON-MATCHING: pretty close but no cigar
-// struct21 *func_10020ABC(struct42 *arg0, struct119 *arg1, s32 arg2, s32 arg3, struct21 *arg4) {
-//     struct21 *sp34;
-//     struct42 *sp30;
-//     struct21 *sp2C;
-//     struct21 *sp28;
-//     struct21 *sp24;
-//     struct21 *sp20;
-//     struct21 *sp1C;
-//
-//     sp34 = arg4;
-//     sp30 = arg0;
-//     if (sp30->unk28 != 0) {
-//         sp30->unk28->unkA = (u8)1;
-//     }
-//     if ((sp30->unk8C != 1) || (arg3 == 0)) {
-//         return sp34;
-//     }
-//
-//     sp34 = func_10022040(sp30, arg1, arg3, arg4);
-//     if (sp30->unk80) {
-//         sp30->unk80 = 0;
-//         sp30->unk70 = (D_8002BC10[(s16)sp30->unk60] * (s16)sp30->unk62) >> 15;
-//         sp30->unk6E = _getRate((s16)sp30->unk64, (s16)sp30->unk70, sp30->unk7C, &sp30->unk6C);
-//         sp30->unk76 = (D_8002BD0E[-(s16)sp30->unk60] * (s16)sp30->unk62) >> 15;
-//         sp30->unk74 = _getRate((s16)sp30->unk66, (s16)sp30->unk76, sp30->unk7C, &sp30->unk72);
-//
-//         sp2C = sp34 = &sp34->unk8;
-//         sp2C->unk0 = ((s16)sp30->unk64 & 0xFFFF) | 0x9060000;
-//         sp2C->unk4 = (((s16)sp30->unk68 & 0xFFFF) << 16) | ((s16)sp30->unk6A & 0xFFFF);
-//
-//         sp28 = sp34 = &sp34->unk8;
-//         sp28->unk0 = ((s16)sp30->unk76 & 0xFFFF) | 0x9040000;
-//         sp28->unk4 = (((s16)sp30->unk74 & 0xFFFF) << 16) | (sp30->unk72 & 0xFFFF);
-//
-//         sp24 = sp34 = &sp34->unk8;
-//         sp24->unk0 = ((s16)sp30->unk70 & 0xFFFF) | 0x9000000;
-//         sp24->unk4 = (((s16)sp30->unk6E & 0xFFFF) << 16) | (sp30->unk6C & 0xFFFF);
-//
-//         sp20 = sp34 = &sp34->unk8;
-//         sp20->unk0 = ((s16)sp30->unk66 & 0xFFFF) | 0x3010000;
-//         sp20->unk4 = osVirtualToPhysical(sp30->unk5C);
-//     } else {
-//         sp1C = sp34 = &sp34->unk8;
-//         sp1C->unk0 = 0x3000000;
-//         sp1C->unk4 = osVirtualToPhysical(sp30->unk5C);
-//         // nop...
-//     }
-//     // just this line :(
-//     arg1 = &arg1->unk170;
-//     sp30->unk78 += 0xb8; // 184
-//     if ((((s16)sp30->unk68 & 2)) || (((s16)sp30->unk6A & 2))) {
-//         sp30->unk68 &= -3; // (s16)sp30->unk68 & -3;
-//         sp30->unk6A &= -3;
-//         sp30->unk80 = 1;
-//     }
-//     return sp34;
-// }
+Cmd *func_10020ABC(SubVoice *arg0, s16 *arg1, s32 arg2, s32 arg3, Cmd *arg4) {
+    Cmd *sp34;
+    SubVoice *sp30;
+    Cmd *sp2C;
+    Cmd *sp28;
+    Cmd *sp24;
+    Cmd *sp20;
+    Cmd *sp1C;
+
+    sp34 = arg4;
+    sp30 = arg0;
+    if (sp30->unk28 != 0) {
+        sp30->unk28->unkA = (u8) 1;
+    }
+    if ((sp30->unk8C != 1) || (arg3 == 0)) {
+        return sp34;
+    }
+
+    sp34 = func_10022040(sp30, arg1, arg3, arg4);
+    if (sp30->unk80) {
+        sp30->unk80 = 0;
+        sp30->unk70 = (D_8002BC10[sp30->unk60] * sp30->unk62) >> 15;
+        sp30->unk6E = _getRate(sp30->unk64, sp30->unk70, sp30->unk7C, &sp30->unk6C);
+        sp30->unk76 = (D_8002BD0E[-sp30->unk60] * sp30->unk62) >> 15;
+        sp30->unk74 = _getRate(sp30->unk66, sp30->unk76, sp30->unk7C, &sp30->unk72);
+
+        sp2C = sp34++;
+        sp2C->w0 = (sp30->unk64 & 0xFFFF) | 0x9060000;
+        sp2C->w1 = ((sp30->unk68 & 0xFFFF) << 16) | (sp30->unk6A & 0xFFFF);
+
+        sp28 = sp34++;
+        sp28->w0 = (sp30->unk76 & 0xFFFF) | 0x9040000;
+        sp28->w1 = ((sp30->unk74 & 0xFFFF) << 16) | (sp30->unk72 & 0xFFFF);
+
+        sp24 = sp34++;
+        sp24->w0 = (sp30->unk70 & 0xFFFF) | 0x9000000;
+        sp24->w1 = ((sp30->unk6E & 0xFFFF) << 16) | (sp30->unk6C & 0xFFFF);
+
+        sp20 = sp34++;
+        sp20->w0 = (sp30->unk66 & 0xFFFF) | 0x3010000;
+        sp20->w1 = osVirtualToPhysical(sp30->unk5C);
+        goto join;
+    }
+    sp1C = sp34++;
+    sp1C->w0 = 0x3000000;
+    sp1C->w1 = osVirtualToPhysical(sp30->unk5C);
+join:
+    arg1[0] += 0x170;
+    sp30->unk78 += 0xB8;
+    if (((sp30->unk68 & 2)) || ((sp30->unk6A & 2))) {
+        sp30->unk68 &= -3;
+        sp30->unk6A &= -3;
+        sp30->unk80 = 1;
+    }
+    return sp34;
+}
 
 s16 _getRate(f32 arg0, f32 arg1, s32 arg2, u16 *arg3) {
     s16 spE;

--- a/conker/src/init_2070.c
+++ b/conker/src/init_2070.c
@@ -1,19 +1,23 @@
 #include <ultra64.h>
+#include <libc/stdarg.h>
 
 #include "functions.h"
 #include "variables.h"
 
+s32 func_100020D0(s32 (*arg0)(s32, s32, s32), s32 arg1, s32 arg2, va_list arg3);
 
 s32 func_10002070(s32 arg0, s32 arg1, s32 arg2) {
     return 1;
 }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/init_2070/func_10002088.s")
-// NOT MATCHING: stack is incorrect
-// void func_10002088(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
-//     D_80035500 = 0;
-//     func_100020D0(func_10002070, 0, arg1, &arg1);
-// }
+void func_10002088(s32 arg0, ...) {
+    va_list ap;
+
+    va_start(ap, arg0);
+    D_80035500 = 0;
+    func_100020D0(func_10002070, 0, arg0, ap);
+    va_end(ap);
+}
 
 // this is a beast:
 #pragma GLOBAL_ASM("asm/nonmatchings/init_2070/func_100020D0.s")

--- a/conker/src/init_214F0.c
+++ b/conker/src/init_214F0.c
@@ -3,9 +3,240 @@
 #include "functions.h"
 #include "variables.h"
 
+typedef struct {
+    u32 w0;
+    u32 w1;
+} Cmd214;
+
+typedef struct {
+    /* 0x0 */ s32 unk0;
+    /* 0x4 */ s32 unk4;
+    /* 0x8 */ s32 unk8;
+    /* 0xC */ u8 data[0x20];
+} LoopInfo_214F0;
+
+typedef struct {
+    /* 0x0 */ s32 unk0;
+    /* 0x4 */ s32 unk4;
+} BookInfo_214F0;
+
+typedef struct {
+    /* 0x00 */ s32 unk0;
+    /* 0x04 */ s32 unk4;
+    /* 0x08 */ s32 unk8;
+    /* 0x0C */ LoopInfo_214F0 *unkC;
+    /* 0x10 */ BookInfo_214F0 *unk10;
+} SampleInfo_214F0;
+
+typedef struct {
+    /* 0x00 */ u8 pad0[0x18];
+    /* 0x18 */ void *unk18;
+    /* 0x1C */ s32 unk1C;
+    /* 0x20 */ s32 unk20;
+    /* 0x24 */ s32 unk24;
+    /* 0x28 */ SampleInfo_214F0 *unk28;
+    /* 0x2C */ s32 unk2C;
+    /* 0x30 */ u8 pad30[0x8];
+    /* 0x38 */ s32 unk38;
+    /* 0x3C */ s32 unk3C;
+    /* 0x40 */ s32 unk40;
+    /* 0x44 */ s32 unk44;
+} Obj_214F0;
+
 // struct21 *func_100214F0(struct42 *arg0, void *arg1, s32 arg2, void *struct21);
 #pragma GLOBAL_ASM("asm/nonmatchings/init_214F0/func_100214F0.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/init_214F0/func_10021C40.s")
+// PERMUTER CANDIDATE: the reconstruction below is algorithmically byte-correct (all logic/structure
+// match; the sp48 and sp5C blocks assemble identically) but is stuck at score ~1935 on a pervasive
+// t3<->t4 register-rotation swap that begins at the sp54 block (obj is colored t4 where the target
+// uses t3) and cascades through the rest. Not reachable by hand; needs the decomp-permuter.
+#if 0
+void func_10007DA0(void);
+void *func_10021E4C(Cmd214 *gfx, struct42 *obj, s32 a2, s32 count, s16 arg4, s16 arg5, s32 flags);
+void *func_100214F0(Obj_214F0 *arg0, s16 *arg1, s32 arg2, Cmd214 *arg3)
+{
+    Cmd214 *gfx;
+    s16 sp7A;
+    s32 sp74;
+    s32 sp70;
+    s32 sp6C;
+    s32 sp68;
+    s32 sp64;
+    s32 sp60;
+    s32 sp5C;
+    s32 sp58;
+    s32 sp54;
+    s32 sp50;
+    s32 sp4C;
+    s32 sp48;
+    Obj_214F0 *obj;
+
+    gfx = arg3;
+    sp4C = 0;
+    sp48 = 0;
+    obj = arg0;
+    if (arg2 == 0) {
+        return gfx;
+    }
+    sp7A = 0;
+    if (obj->unk28 == 0) {
+        Cmd214 *slot = gfx++;
+        slot->w0 = (*arg1 & 0xFFFFFF) | 0x02000000;
+        slot->w1 = arg2 << 1;
+        return gfx;
+    }
+    if ((((u32)obj->unk28->unk10 + 8) & 0x1FFFFFFF) >= 0x800001) {
+        D_8003C8E0 = 0x0F000003;
+        func_10007DA0();
+    }
+    {
+        Cmd214 *slot = gfx++;
+        slot->w0 = (obj->unk2C & 0xFFFFFF) | 0x0B000000;
+        slot->w1 = ((u32)obj->unk28->unk10 + 8) & 0x1FFFFFFF;
+    }
+    sp48 = ((u32)obj->unk20 < (u32)(obj->unk38 + arg2)) && obj->unk24;
+    if (sp48) {
+        sp5C = obj->unk20 - obj->unk38;
+    } else {
+        sp5C = arg2;
+    }
+    if (obj->unk3C) {
+        sp54 = 0x10 - obj->unk3C;
+    } else {
+        sp54 = 0;
+    }
+    sp74 = sp5C - sp54;
+    if (sp74 < 0) {
+        sp74 = 0;
+    }
+    sp70 = (sp74 + 0xF) >> 4;
+    sp6C = sp70 * 9;
+    if (sp48) {
+        gfx = func_10021E4C(gfx, (struct42 *)obj, sp74, sp6C, *arg1, sp7A, obj->unk40);
+        if (obj->unk3C) {
+            *arg1 = *arg1 + (obj->unk3C << 1);
+        } else {
+            *arg1 = *arg1 + 0x20;
+        }
+        obj->unk3C = obj->unk1C & 0xF;
+        obj->unk44 = (s32)obj->unk28->unk0 + ((u32)obj->unk1C >> 4) * 9 + 9;
+        obj->unk38 = obj->unk1C;
+        sp50 = *arg1;
+        if (arg2 > sp5C) {
+            do {
+                arg2 = arg2 - sp5C;
+                sp58 = (((sp70 + 1) << 5) + sp50 + 0x10) & -0x20;
+                sp50 = sp50 + (sp5C << 1);
+                if (obj->unk24 != -1 && obj->unk24 != 0) {
+                    obj->unk24 = obj->unk24 - 1;
+                }
+                if ((u32)arg2 < (u32)(obj->unk20 - obj->unk1C)) {
+                    sp5C = arg2;
+                } else {
+                    sp5C = obj->unk20 - obj->unk1C;
+                }
+                sp74 = sp5C + obj->unk3C - 0x10;
+                if (sp74 < 0) {
+                    sp74 = 0;
+                }
+                sp70 = (sp74 + 0xF) >> 4;
+                sp6C = sp70 * 9;
+                gfx = func_10021E4C(gfx, (struct42 *)obj, sp74, sp6C, sp58, sp7A, obj->unk40 | 2);
+                {
+                    Cmd214 *slot = gfx++;
+                    slot->w0 = (((obj->unk3C << 1) + sp58) & 0xFFFFFF) | 0x0A000000;
+                    slot->w1 = ((sp50 & 0xFFFF) << 16) | ((sp5C << 1) & 0xFFFF);
+                }
+            } while (arg2 > sp5C);
+        }
+        obj->unk3C = (obj->unk3C + arg2) & 0xF;
+        obj->unk38 = obj->unk38 + arg2;
+        obj->unk44 = obj->unk44 + sp70 * 9;
+        return gfx;
+    } else {
+        sp5C = sp70 << 4;
+        sp68 = (obj->unk44 + sp6C) - ((s32)obj->unk28->unk0 + obj->unk28->unk4);
+        if (sp68 < 0) {
+            sp68 = 0;
+        }
+        sp60 = (sp68 / 9) << 4;
+        if (sp5C + sp54 < sp60) {
+            sp60 = sp5C + sp54;
+        }
+        sp6C = sp6C - sp68;
+        if (sp60 - (sp60 & 0xF) < arg2) {
+            sp4C = 1;
+            gfx = func_10021E4C(gfx, (struct42 *)obj, sp5C - sp60, sp6C, *arg1, sp7A, obj->unk40);
+            if (obj->unk3C) {
+                *arg1 = *arg1 + (obj->unk3C << 1);
+            } else {
+                *arg1 = *arg1 + 0x20;
+            }
+            obj->unk3C = (obj->unk3C + arg2) & 0xF;
+            obj->unk38 = obj->unk38 + arg2;
+            obj->unk44 = obj->unk44 + sp70 * 9;
+        } else {
+            obj->unk3C = 0;
+            obj->unk44 = obj->unk44 + sp70 * 9;
+        }
+        if (sp60 != 0) {
+            obj->unk3C = 0;
+            if (sp4C) {
+                sp64 = ((sp54 + sp5C) - sp60) << 1;
+            } else {
+                sp64 = 0;
+            }
+            {
+                Cmd214 *slot = gfx++;
+                slot->w0 = ((*arg1 + sp64) & 0xFFFFFF) | 0x02000000;
+                slot->w1 = sp60 << 1;
+            }
+        }
+        return gfx;
+    }
+}
+
+#endif
+
+s32 func_10021C40(Obj_214F0 *arg0, s32 arg1, void *arg2)
+{
+    switch (arg1) {
+    case 5:
+        arg0->unk28 = arg2;
+        arg0->unk44 = arg0->unk28->unk0;
+        arg0->unk38 = 0;
+        arg0->unk28->unk4 = arg0->unk28->unk4 / 9 * 9;
+        if (((u32)arg0->unk28->unk10 & 0xFF000003) != 0x80000000) {
+            arg0->unk24 = 0;
+            arg0->unk1C = arg0->unk20 = arg0->unk24;
+            break;
+        } else {
+            arg0->unk2C = arg0->unk28->unk10->unk0 * 2 * arg0->unk28->unk10->unk4 * 8;
+        }
+        if (arg0->unk28->unkC != 0) {
+            arg0->unk1C = arg0->unk28->unkC->unk0;
+            arg0->unk20 = arg0->unk28->unkC->unk4;
+            arg0->unk24 = arg0->unk28->unkC->unk8;
+            bcopy(arg0->unk28->unkC->data, arg0->unk18, 0x20);
+        } else {
+            arg0->unk24 = 0;
+            arg0->unk1C = arg0->unk20 = arg0->unk24;
+        }
+        break;
+    case 4:
+        arg0->unk3C = 0;
+        arg0->unk40 = 1;
+        arg0->unk38 = 0;
+        if (arg0->unk28 != 0) {
+            arg0->unk44 = arg0->unk28->unk0;
+            arg0->unk24 = 0;
+        }
+        break;
+    default:
+        break;
+    }
+    return 0;
+}
+
 // ? func_10021C40(void *arg0, s32 arg1, s32 arg2) {
 //     s32 temp_s0;
 //     s32 temp_s0_2;
@@ -54,4 +285,39 @@
 //     return 0;
 // }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/init_214F0/func_10021E4C.s")
+void *func_10021E4C(Cmd214 *gfx, struct42 *obj, s32 a2, s32 count, s16 arg4, s16 arg5, s32 flags)
+{
+    s32 align;
+    s32 res;
+
+    if (count > 0) {
+        res = ((s32 (*)(s32, s32, s32))obj->unk30)(obj->unk44, count, obj->unk34);
+        if (res == 0) {
+            obj->unk80 = 1;
+            obj->unk62 = 0;
+            obj->unk40 = 0;
+            return gfx;
+        }
+        align = res & 7;
+        count = count + align;
+        {
+            Cmd214 *_a = gfx++;
+            _a->w0 = ((((count - (count & 7)) + 8) & 0xFFF) << 12) | 0x04000000 | (arg5 & 0xFFF);
+            _a->w1 = res - align;
+        }
+    } else {
+        align = 0;
+    }
+    if (flags & 2) {
+        Cmd214 *_a = gfx++;
+        _a->w0 = 0x0F000000;
+        _a->w1 = obj->unk18 & 0x1FFFFFFF;
+    }
+    {
+        Cmd214 *_a = gfx++;
+        _a->w0 = (obj->unk14 & 0x1FFFFFFF & 0x00FFFFFF) | 0x01000000;
+        _a->w1 = ((flags & 0xF) << 28) | (((a2 << 1) & 0xFFF) << 16) | ((align & 0xF) << 12) | (arg4 & 0xFFF);
+    }
+    obj->unk40 = 0;
+    return gfx;
+}

--- a/conker/src/init_22040.c
+++ b/conker/src/init_22040.c
@@ -1,48 +1,68 @@
 #include "n_synthInternals.h"
 
+extern f32 D_8002C830;
+extern f32 D_8002C834;
+extern f32 D_8002C838;
 
-#pragma GLOBAL_ASM("asm/nonmatchings/init_22040/func_10022040.s")
-// NON-MATCHING: 80% matching
-// struct21 *func_10022040(struct42 *arg0, struct119 *arg1, s32 arg2, struct21 *arg3) {
-//     struct21 *sp2C;
-//     f32 sp28;
-//     struct21 *sp24;
-//     struct21 *sp20;
-//     struct21 *sp1C;
-//
-//     sp2C = arg3;
-//     sp2C = func_10022460(arg0, arg1, arg3);
-//
-//     if ((arg0->unk99 != 0) && (arg0->unk99 < 64)) {
-//         if (arg0->unk99 >= 6) {
-//             sp28 = D_8002C820 / sqrtf(arg0->unk99 + 1.0f);
-//         } else {
-//             sp28 = 65536.0f / (arg0->unk99 + 1.0f);
-//         }
-//         if (sp28 < D_8002C834) {
-//             sp28 = D_8002C838;
-//         }
-//         sp24 = sp2C = &sp2C->unk8;
-//         sp24->unk0 = ((s32)arg1 & 0xFFFF);
-//         sp24->unk4 =  (((u32) sp28 & 0xFFFF) << 16) | (arg0->unk99 + 1);
-//     }
-//     if ((s16)arg0->unkA2 > 0) {
-//         if (arg0->unkC8 != 0) {
-//             func_1001CF38(&arg0->unkA0, 22050.0f);
-//         }
-//         sp20 = sp2C = &sp2C->unk8;
-//         sp20->unk0 = 0xB000020;
-//         sp20->unk4 = osVirtualToPhysical(&arg0->unkA8);
-//         if (arg0->unkC8 == 2) {
-//             arg0->unkC8 = 0;
-//         }
-//         sp1C = sp2C = &sp2C->unk8;
-//         sp1C->unk0 = (((s32)arg1 & 0xFFFF) | (((arg0->unkC8 & 0xFF) << 0x10) | 0xE000000));
-//         sp1C->unk4 = (osVirtualToPhysical(arg0->unkCC) & 0xFFFFFF & 0xFFFFFF);
-//         arg0->unkC8 = 0;
-//     }
-//     return sp2C;
-// }
+typedef struct { u32 w0; u32 w1; } Cmd;
+
+typedef struct {
+    u8  pad0[0x99];
+    /* 0x99 */ u8   unk99;
+    u8  pad9A[0x6];
+    /* 0xA0 */ s16  unkA0;
+    /* 0xA2 */ s16  unkA2;
+    u8  padA4[0x4];
+    /* 0xA8 */ s16  unkA8;
+    u8  padAA[0x1E];
+    /* 0xC8 */ s32  unkC8;
+    /* 0xCC */ void *unkCC;
+} Voice;
+
+Cmd *func_10022460(Voice *, s16 *, Cmd *);
+void func_1001CF38(void *, f32);
+f32 sqrtf(f32);
+
+Cmd *func_10022040(Voice *arg0, s16 *arg1, s32 arg2, Cmd *arg3) {
+    Cmd *sp2C;
+    f32 sp28;
+    Cmd *sp24;
+    Cmd *sp20;
+    Cmd *sp1C;
+
+    sp2C = arg3;
+    sp2C = func_10022460(arg0, arg1, arg3);
+
+    if ((arg0->unk99 != 0) && (arg0->unk99 < 64)) {
+        if (arg0->unk99 >= 6) {
+            sp28 = D_8002C830 / sqrtf((f32) arg0->unk99 + 1.0f);
+        } else {
+            sp28 = 65536.0f / ((f32) arg0->unk99 + 1.0f);
+        }
+        if (sp28 < D_8002C834) {
+            sp28 = D_8002C838;
+        }
+        sp24 = sp2C++;
+        sp24->w0 = arg1[0] & 0xFFFF;
+        sp24->w1 = (((u32) sp28 & 0xFFFF) << 16) | ((arg0->unk99 + 1) & 0xFFFF);
+    }
+    if (arg0->unkA2 > 0) {
+        if (arg0->unkC8 != 0) {
+            func_1001CF38(&arg0->unkA0, 22050.0f);
+        }
+        sp20 = sp2C++;
+        sp20->w0 = 0xB000020;
+        sp20->w1 = osVirtualToPhysical(&arg0->unkA8);
+        if (arg0->unkC8 == 2) {
+            arg0->unkC8 = 0;
+        }
+        sp1C = sp2C++;
+        sp1C->w0 = (arg1[0] & 0xFFFF) | (((arg0->unkC8 & 0xFF) << 16) | 0xE000000);
+        sp1C->w1 = osVirtualToPhysical(arg0->unkCC) & 0xFFFFFF & 0xFFFFFF;
+        arg0->unkC8 = 0;
+    }
+    return sp2C;
+}
 
 s32 n_alLoadParam(N_PVoice *filter, s32 paramID, void *param) {
     f32 *sp24 = &param;

--- a/conker/src/init_3BD0.c
+++ b/conker/src/init_3BD0.c
@@ -4,5 +4,17 @@
 #include "variables.h"
 
 
-// NON-MATCHING: who knows what this is..
-#pragma GLOBAL_ASM("asm/nonmatchings/init_3BD0/func_10003BD0.s")
+void func_10003BD0(void) {
+    struct54 *tmp;
+
+    D_800380B4 = (struct54 *)&D_800E9D10;
+    D_800380B4->unk0 = NULL;
+    D_800380B4->unk4 = NULL;
+    D_800380B4->unk8 = D_80038098 - (u32)&D_800E9D10 - 0x14;
+    D_800380B4->unkC = 0;
+    D_800380B4->unk10 = 0;
+    tmp = D_800380B4;
+    D_800380BC = (s32 *)tmp;
+    D_800380B8 = (struct54 *)D_800380BC;
+    D_800380B0 = tmp;
+}

--- a/conker/src/init_3C40.c
+++ b/conker/src/init_3C40.c
@@ -3,6 +3,16 @@
 #include "functions.h"
 #include "variables.h"
 
+// File-local view of the allocator block header (struct54 in structs.h declares
+// unkC/unk10 as s32, but this function walks them as pointers).
+typedef struct L54 {
+    /* 0x00 */ struct L54 *unk0;   // next physical block
+    /* 0x04 */ struct L54 *unk4;   // prev physical block
+    /* 0x08 */ u32 unk8;           // tag<<24 | size
+    /* 0x0C */ struct L54 *unkC;   // free-list forward
+    /* 0x10 */ struct L54 *unk10;  // free-list backward
+} L54;
+
 
 s32 allocate_memory(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
     return func_10003C6C(arg0, arg1, arg2, 0, arg3);
@@ -10,6 +20,60 @@ s32 allocate_memory(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
 
 #pragma GLOBAL_ASM("asm/nonmatchings/init_3C40/func_10003C6C.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/init_3C40/func_10004074.s")
+// PERMUTER NO ZERO, best 476 (was 1301). Allocator free() with prev/next
+// physical coalescing + sorted free-list re-insertion. Control flow matches the
+// target exactly. Permuter (~30k iters, 2 runs + chain) plateaued at 370 in its
+// isolated harness / 476 in full build; never zeroed. Two permuter-found tweaks
+// help and are folded into the reconstruction below:
+//   (1) `volatile int mask` forces mask to a spill slot (matches target)  -> 741
+//   (2) re-reading `((L54 *)D_800380B8) == NULL` in the !coalesced guard    -> 476
+// Remaining diff is the documented coupled reg/frame cascade, not reachable from
+// C: IDO copies arg0 into a2 (frame 0x30, node->v1, mask@0x1c); this recon gets
+// arg0->a3 (frame 0x38, node->a2), and the a2-vs-a3 choice cascades through the
+// whole body (node/cur reg-numbering) plus higher spill-slot packing.
+// void func_10004074(void *arg0) {
+//     L54 *node; L54 *cur; volatile int mask; s32 coalesced; L54 *prev; L54 *next;
+//     if (arg0 == NULL) { return; }
+//     node = (L54 *)((u8 *)arg0 - 0xC);
+//     cur = node;
+//     coalesced = 0;
+//     mask = osSetIntMask(1);
+//     *(u8 *)&node->unk8 = 0;
+//     prev = node->unk4;
+//     if ((prev != NULL) && ((prev->unk8 >> 24) == 0)) {
+//         next = node->unk0; cur = prev; coalesced = 1;
+//         prev->unk0 = next;
+//         prev->unk8 = prev->unk8 + node->unk8 + 0xC;
+//         if (next != NULL) { next->unk4 = cur; }
+//     }
+//     next = cur->unk0;
+//     if ((next != NULL) && ((next->unk8 >> 24) == 0)) {
+//         prev = next->unk0; cur->unk0 = prev; coalesced = 1;
+//         cur->unk8 = cur->unk8 + next->unk8 + 0xC;
+//         if (prev != NULL) { prev->unk4 = cur; }
+//         prev = next->unkC; cur->unkC = prev;
+//         if (prev != NULL) { prev->unk10 = cur; }
+//         prev = next->unk10;
+//         if (prev == NULL) { D_800380B8 = (struct54 *)cur; cur->unk10 = NULL; }
+//         else if (prev != cur) { cur->unk10 = prev; if (prev != NULL) { prev->unkC = cur; } }
+//     }
+//     if (!coalesced) {
+//         prev = (L54 *)D_800380B8;
+//         if (((L54 *)D_800380B8) == NULL) { cur->unkC = NULL; cur->unk10 = NULL; D_800380B8 = (struct54 *)cur; }
+//         else if (cur < prev) { cur->unkC = prev; cur->unk10 = NULL; prev->unk10 = cur; D_800380B8 = (struct54 *)cur; }
+//         else {
+//             for (;;) {
+//                 next = prev->unkC;
+//                 if (next == NULL) { cur->unkC = NULL; cur->unk10 = prev; prev->unkC = cur; break; }
+//                 if (cur < next) { cur->unkC = next; cur->unk10 = prev; next->unk10 = cur; prev->unkC = cur; break; }
+//                 prev = next;
+//             }
+//         }
+//     }
+//     if (cur->unkC == NULL) { D_800380BC = (s32 *)cur; }
+//     if ((u32)D_8002AC30 < cur->unk8) { D_8002AC30 = cur->unk8; D_800380B0 = (struct54 *)cur; }
+//     osSetIntMask(mask);
+// }
 
 void func_10004250(void) {
     s32 temp_v0;
@@ -54,13 +118,15 @@ void func_10004308(void) {
     osSetIntMask(mask);
 }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/init_3C40/func_100043B4.s")
-// NON-MATCHING: missing an addiu
-// void func_100043B4(s32 *arg0, u32 arg1) {
-//     OSIntMask mask = osSetIntMask(1);
-//     *(arg0 - 1) = (arg1 << 24) | *(arg0 - 1) & 0xFFFFFF;
-//     osSetIntMask(mask);
-// }
+void func_100043B4(s32 *arg0, u32 arg1) {
+    OSIntMask mask;
+    struct54 *node;
+
+    mask = osSetIntMask(1);
+    node = (struct54 *)((u32)arg0 - 0xC);
+    node->unk8 = (node->unk8 & 0xFFFFFF) | (arg1 << 24);
+    osSetIntMask(mask);
+}
 
 void func_1000440C(void) {
     struct54 *foo;

--- a/conker/src/init_4470.c
+++ b/conker/src/init_4470.c
@@ -67,44 +67,34 @@ void func_10004674(void) {
     D_8003A571 = 0;
 }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/init_4470/func_100046E4.s")
-// NON-MATCHING: stack isnt right
-// void func_100046E4(s32 devAddr, void *dramAddr, u32 size) {
-//     s32 _dramAddr;
-//     s32 idx;
-//     s32 threadId;
-//     s32 _devAddr; // pad
-//     OSMesgQueue *mesgQueue;
-//     OSIoMesg *sp68;
-//     OSIoMesg *sp64; // mesg?
-//     u32 _size;
-//     u32 sent;
-//
-//
-//     threadId = __osRunningThread->id - 3;
-//     if ((threadId >= 4) || (idx = threadId, (threadId < 0))) {
-//         idx = 0;
-//     }
-//     sent = 0;
-//     osInvalDCache(dramAddr, size);
-//     if (size != 0) {
-//         mesgQueue =  &gMessageQueue[idx];
-//         _dramAddr = dramAddr;
-//         // _devAddr = devAddr;
-//         do {
-//             if ((size - sent) < 81920) {
-//                 _size = size - sent;
-//             } else {
-//                 _size = 81920;
-//             }
-//             osPiStartDma(&sp68, 0, 0, devAddr, _dramAddr, _size, mesgQueue);
-//             osRecvMesg(mesgQueue, &sp64, 1);
-//             sent += _size;
-//             devAddr += _size;
-//             _dramAddr += _size;
-//         } while (sent < size) ;
-//     }
-// }
+void func_100046E4(s32 devAddr, void *dramAddr, u32 size) {
+    OSIoMesg sp68;
+    OSMesg sp64;
+    s32 idx;
+    u32 chunk;
+    u32 sent;
+
+    idx = __osRunningThread->id - 3;
+    if ((idx >= 4) || (idx < 0)) {
+        idx = 0;
+    }
+    sent = 0;
+    osInvalDCache(dramAddr, size);
+    if (size != 0) {
+        do {
+            if ((size - sent) < 81920) {
+                chunk = size - sent;
+            } else {
+                chunk = 81920;
+            }
+            osPiStartDma(&sp68, 0, 0, devAddr, dramAddr, chunk, &gMessageQueue[idx]);
+            osRecvMesg(&gMessageQueue[idx], &sp64, 1);
+            sent += chunk;
+            devAddr += chunk;
+            dramAddr = (void *)((u8 *)dramAddr + chunk);
+        } while (sent < size);
+    }
+}
 
 #pragma GLOBAL_ASM("asm/nonmatchings/init_4470/func_1000480C.s")
 // void func_1000480C(s32 devAddr, void *dramAddr, u32 size) {

--- a/conker/src/init_49E0.c
+++ b/conker/src/init_49E0.c
@@ -127,32 +127,30 @@
 //     goto loop_1;
 // }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/init_49E0/func_10004DB0.s")
-// NON-MATCHING: branching is not right
-// void func_10004DB0(void) {
-//     if (D_8003A582 == 0) {
-//         if (osRecvMesg(&D_8003B1E8, &D_8002AC50, 0) == 0) {
-//             if ((osViGetCurrentFramebuffer() == D_8002AC50->framebuffer) ||
-//                 (osViGetNextFramebuffer() == D_8002AC50->framebuffer) ||
-//                 ((D_8003B23A != 0) && (D_8003B238 < D_8003B239))) {
-//                 D_8003A582 = 2;
-//             } else {
-//                 if (D_8003B238 != 255) {
-//                     if ((D_8003B238 >= D_8003B239) || (D_8003B23A == 0)) {
-//                         D_8003B239 = D_8003B238;
-//                     }
-//                 }
-//                 func_10004F00();
-//             }
-//         }
-//     } else if (D_8003A582 == 2) {
-//         if ((D_8003B23A == 0) || ( D_8003B238 >= D_8003B239)) {
-//             func_10004F00();
-//         }
-//     } else if (D_8003A582 == 6) {
-//         func_10004FE0();
-//     }
-// }
+void func_10004DB0(void) {
+    if (D_8003A582 == 0) {
+        if (osRecvMesg(&D_8003B1E8, &D_8002AC50, 0) == 0) {
+            if ((osViGetCurrentFramebuffer() != D_8002AC50->framebuffer) &&
+                (osViGetNextFramebuffer() != D_8002AC50->framebuffer) &&
+                ((D_8003B23A == 0) || (D_8003B238 >= D_8003B239))) {
+                if (D_8003B238 != 255) {
+                    if ((D_8003B238 >= D_8003B239) || (D_8003B23A == 0)) {
+                        D_8003B239 = D_8003B238;
+                    }
+                }
+                func_10004F00();
+            } else {
+                D_8003A582 = 2;
+            }
+        }
+    } else if (D_8003A582 == 2) {
+        if ((D_8003B23A == 0) || (D_8003B238 >= D_8003B239)) {
+            func_10004F00();
+        }
+    } else if (D_8003A582 == 6) {
+        func_10004FE0();
+    }
+}
 
 void func_10004F00(void) {
     if (D_8002AC5C == 0) {

--- a/conker/src/init_8180.c
+++ b/conker/src/init_8180.c
@@ -25,6 +25,7 @@ void func_10017DF0(N_ALCSPlayer *csp, f32 arg1, f32 arg2);
 void func_10017E4C(N_ALCSPlayer *csp, u8 chan, u8 arg2);
 void func_10017F10(N_ALCSPlayer *arg0, u8 arg1, u8 arg2, u8 arg3, s32 arg4);
 void func_10018790(N_ALCSPlayer *arg0, s32 arg1, u32 arg2, u32 arg3);
+void func_100186DC(void *arg0, void *arg1);
 void func_10018D00(N_ALCSPlayer *arg0, s16 arg1);
 void func_10018D50(N_ALCSPlayer *seqp);
 
@@ -170,51 +171,42 @@ void func_10008C04(u8 idx, u8 arg1, s32 arg2) {
     func_10018790(&D_8003CA58[idx], &D_8003CD48[idx], arg1, arg2);
 }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/init_8180/func_10008C6C.s")
-// NON-MATCHING: need to determine what these variables hold
-// void func_10008C6C(u8 idx, u8 arg1) {
-//     func_100186DC(&D_8003CA58[idx], &D_8003CD48[idx + (arg1 * 0xEC)]); // (idx * 0x760)
-// }
+void func_10008C6C(u8 idx, u8 arg1) {
+    func_100186DC(&D_8003CA58[idx], &D_8003CD48[idx].pad0[arg1 * 0xEC]);
+}
 
 #pragma GLOBAL_ASM("asm/nonmatchings/init_8180/func_10008CE8.s")
-// NON-MATCHING: 80% of the way there
-// s32 func_10008CE8(u8 idx, u16 arg1) {
-//     s32 sp3C;
-//     ALCSeq *temp_s0_3;
-//     u32 i;
-//
+// PERMUTER NO ZERO, best 20 (was 235). The permuter's new_var temp-split
+// (`new_var = D_8003CA48[idx]; func_10004074(new_var);`) collapses the old
+// v0/v1 register diff, dropping the isolated score to 0. But in the full-file
+// build the residual is a pure frame-packing diff the permuter is blind to:
+// the two compiler-homed temps land at 0x30/0x28 (idx<<2 / &D_8003CA3C[idx])
+// vs the target's 0x34/0x2c, while sp3C@0x3c matches. Swept all 3-local decl
+// orders (best 20 with sp3C declared first, else 28) + named-pointer homing
+// (98); none reach the target slots. Not reachable from C. Needs file-local:
+//   typedef struct { s32 unk0; s32 unk4; } StructCD40;
+//   extern u16 D_8003CA3C[]; extern u8 *D_8003CA48[];
+//   extern StructCD40 *D_8003CD40; extern u16 D_8003C910[];
+// s32 func_10008CE8(u8 idx, s32 arg1) {
+//     s32 sp3C; u8 *new_var; u32 i;
 //     i = 0;
-//     func_10018C60(&D_8003C900[idx]);
-//     while ((n_alCSPGetState(&D_8003C900[idx]) != 0) && (i < 2000000)) {
-//         i++;
-//     };
-//
+//     func_10018C60(D_8003C900[idx]);
+//     while ((n_alCSPGetState(D_8003C900[idx]) != 0) && (i < 2000000)) i++;
 //     if (i >= 2000000) {
-//         func_10018C60(&D_8003C900[idx]);
-//         while ((n_alCSPGetState(&D_8003C900[idx]) != 0) && (i < 4000000)) {
-//             i++;
-//         }
+//         func_10018C60(D_8003C900[idx]);
+//         while ((n_alCSPGetState(D_8003C900[idx]) != 0) && (i < 4000000)) i++;
 //     }
-//
 //     if (arg1 != D_8003CA3C[idx]) {
-//         if (D_8003CA48[idx] != NULL) {
-//             func_10004074(&D_8003CA48[idx]); // de-init?
-//             D_8003CA48[idx] = NULL;
-//         }
-//
+//         if (D_8003CA48[idx] != NULL) { new_var = D_8003CA48[idx]; func_10004074(new_var); D_8003CA48[idx] = NULL; }
 //         sp3C = D_8003CD40[arg1].unk4;
-//         temp_s0_3 = allocate_memory(&D_8003C910[arg1], 0xFF, 2, 2);
-//         if (temp_s0_3 == NULL) {
-//             return -1;
-//         }
-//         func_10004514(sp3C, temp_s0_3, ALIGN16(D_8003C910[arg1]), 1);
+//         D_8003CA48[idx] = allocate_memory(D_8003C910[arg1], 0xFF, 2, 2);
+//         if (D_8003CA48[idx] == NULL) return -1;
+//         func_10004514(sp3C, D_8003CA48[idx], ALIGN16(D_8003C910[arg1]), 1);
 //         D_8003CA3C[idx] = arg1;
-//       }
-//
-//     n_alCSeqNew(&D_8003CA58[idx], &D_8003CA48[idx]);
-//     func_10018CB0(&D_8003C900[idx], &D_8003CA58[idx]);
-//     func_10017B30(&D_8003C900[idx]);
-//
+//     }
+//     n_alCSeqNew(&D_8003CA58[idx], D_8003CA48[idx]);
+//     func_10018CB0(D_8003C900[idx], &D_8003CA58[idx]);
+//     func_10017B30(D_8003C900[idx]);
 //     return 0;
 // }
 

--- a/conker/src/init_B1B0.c
+++ b/conker/src/init_B1B0.c
@@ -3,6 +3,8 @@
 #include "functions.h"
 #include "variables.h"
 
+void func_1000DEC4(void);
+
 
 struct151 *func_1000B1B0(s32 arg0) {
     s32 i;
@@ -18,22 +20,31 @@ struct151 *func_1000B1B0(s32 arg0) {
 }
 
 #pragma GLOBAL_ASM("asm/nonmatchings/init_B1B0/func_1000B1FC.s")
-// NON-MATCHING: something like this, but not this.
-// struct151 *func_1000B1FC(s32 arg0) {
-//     struct151 *phi_v1_2;
-//     u32 i;
+// NON-MATCHING (asm-differ score 30, but every instruction is identical).
+// The code below produces the exact 38 instructions of the target. The only
+// difference is which symbol the two loop-end addresses relocate against:
+// the .s says %hi/%lo(D_800417BC) while the compiler emits
+// %hi(D_800417B0)/%lo(D_800417B0+0xc). Both resolve to 0x800417BC, so the
+// linked ROM bytes are identical; only the .o relocation entries differ.
+// Writing the loops as pointer walks against &D_800417BC does emit the right
+// symbol, but IDO then unrolls them 4x (152 -> 352 bytes) because the trip
+// count is no longer a compile-time constant.
 //
-//     for (i = 0; i < D_800417BC; i += 4) {
-//         if ( D_800417B0[i] != 0 &&  D_800417B0[i]->unk4 == arg0) {
-//             return  D_800417B0[i];
+// struct151 *func_1000B1FC(s32 arg0) {
+//     struct151 *temp;
+//     s32 i;
+//
+//     for (i = 0; i < 3; i++) {
+//         if ((D_800417B0[i] != NULL) && (D_800417B0[i]->unk4 == arg0)) {
+//             return D_800417B0[i];
 //         }
 //     }
 //
-//     for (i = 0; i < D_800417BC; i += 4) {
-//         if ( D_800417B0[i] != 0) {
-//             phi_v1_2 =  D_800417B0[i]->unk60;
-//             if (phi_v1_2 != 0 && phi_v1_2->unk4 == arg0) {
-//                 return phi_v1_2;
+//     for (i = 0; i < 3; i++) {
+//         if (D_800417B0[i] != NULL) {
+//             temp = (struct151 *) D_800417B0[i]->unk60;
+//             if ((temp != NULL) && (temp->unk4 == arg0)) {
+//                 return temp;
 //             }
 //         }
 //     }
@@ -42,31 +53,26 @@ struct151 *func_1000B1B0(s32 arg0) {
 // }
 
 #pragma GLOBAL_ASM("asm/nonmatchings/init_B1B0/func_1000B294.s")
-// NON-MATCHING: no idea.
-// struct151 * func_1000B294(s32 *arg0) {
-//     s32 i;
-//     struct151 *phi_v1;
-//     struct151 *tmp;
-//     struct151 *ret = NULL;
+// NON-MATCHING (asm-differ score 10, but every instruction is identical).
+// Same situation as func_1000B1FC: the code below emits all 24 target
+// instructions; only the loop-end relocation differs (.s uses D_800417BC,
+// the compiler uses D_800417B0+0xc - same address, identical linked bytes).
 //
-//     for (i = 0; i < 3; i++)
-//     {
-//         phi_v1 = &D_800417B0[i];
-//         ret = phi_v1;
-//         if (phi_v1)
-//         {
-//             if (arg0 == phi_v1->unk10)
-//             {
-//                 phi_v1->unk10 = phi_v1;
+// void func_1000B294(s32 *arg0) {
+//     struct151 *temp;
+//     s32 i;
+//
+//     for (i = 0; i < 3; i++) {
+//         if (D_800417B0[i] != NULL) {
+//             if (arg0 == D_800417B0[i]->unk10) {
+//                 D_800417B0[i]->unk10 = (s32 *) D_800417B0[i];
 //             }
-//             tmp = *phi_v1->unk60;
-//             if ((tmp) && (arg0 == tmp->unk10))
-//             {
-//                 phi_v1->unk10 = tmp;
+//             temp = (struct151 *) D_800417B0[i]->unk60;
+//             if ((temp != NULL) && (arg0 == temp->unk10)) {
+//                 temp->unk10 = (s32 *) temp;
 //             }
 //         }
 //     }
-//     return ret;
 // }
 
 struct137 *func_1000B2F4(s32 arg0) {
@@ -115,6 +121,9 @@ s32 func_1000B548(s32 *arg0) {
 }
 
 #pragma GLOBAL_ASM("asm/nonmatchings/init_B1B0/func_1000B638.s")
+// NON-MATCHING (score 3592): logic reconstructed but the stack frame comes out
+// 0x28 vs the target's 0x20 (target keeps the arg0&1 flag in a3 and reuses arg
+// homes for call-spills). Frame/register-allocation mismatch.
 
 
 s32 func_1000B830(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
@@ -178,7 +187,24 @@ s32 func_1000BA18(u32 arg0, u8 arg1, f32 arg2, f32 arg3, f32 arg4) {
     return arg0 | sp44;
 }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/init_B1B0/func_1000BAFC.s")
+s32 func_1000BAFC(u32 arg0, u8 arg1, f32 arg2, f32 arg3, f32 arg4) {
+    u32 sp44;
+    s32 sp40;
+    s32 sp3C;
+
+    sp44 = 0;
+    sp3C = arg0 & 0x00FFFFFF;
+    arg0 = arg0 & 0xFF000000;
+    func_100114D0(0, 0, 0, 0x7FF8, 0xE74, 0xA28, &sp40, &sp44, 0);
+    sp44 = ((0x7FFF - sp44) << 16) & 0xFF000000;
+    if (arg0 != sp44) {
+        arg0 = sp44;
+        func_1000E588(0x93, arg0 >> 24, 0x6000);
+    }
+    sp3C = func_1000C530(sp3C, arg1, arg2, arg3, arg4) & 0xFFFFFF;
+    sp44 = sp3C & 0xFFFFFFFFFFFFFFFF;
+    return arg0 | sp44;
+}
 
 s32 func_1000BBE8(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
     if (arg0 == 0) {
@@ -207,12 +233,92 @@ s32 func_1000BC28(s32 arg0, u8 arg1, s32 arg2, s32 arg3) {
 
 #pragma GLOBAL_ASM("asm/nonmatchings/init_B1B0/func_1000BCBC.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/init_B1B0/func_1000BF60.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/init_B1B0/func_1000C350.s")
+extern u8 D_800C35E8;
+extern void func_15178EFC(s32);
+
+s32 func_1000C350(s32 arg0, u8 arg1, s32 arg2, s32 arg3) {
+    s32 new_var;
+
+    if ((arg0 & 0x80) == 0) {
+        arg0 |= 0x80;
+        if (D_800C35EA != 1) {
+            func_1000886C(arg1, 0x1E, 1);
+            func_1000886C(arg1, 1, 1);
+            func_1000E40C(0x23, 0x61A8);
+        } else {
+            if (D_800C35E8 == 3) {
+                func_1000E40C(0x23, 0xFA);
+                func_15178EFC(2);
+            } else if (D_800C35E8 == 6) {
+                func_1000886C(arg1, 0x1E, 1);
+                func_1000886C(arg1, 1, 0x40);
+                func_15178EFC(2);
+            } else {
+                func_1000E40C(0x23, 0x61A8);
+            }
+        }
+        return arg0;
+    }
+    new_var = arg0 & 0x7F;
+    if (D_800BE9F0 != 0x1D) {
+        func_10008F24(arg1);
+        return arg0;
+    }
+    if (new_var != D_80041F08) {
+        switch (D_80041F08) {
+        case 1:
+            func_10008790(arg1, 0x1E, 0, 0);
+            func_10008790(arg1, 1, 0x40, 0);
+            break;
+        case 2:
+            func_10008790(arg1, 0x18, 0xFF, 0);
+            func_10008790(arg1, 6, 0, 0);
+            func_10008790(arg1, 1, 1, 0);
+            break;
+        }
+        arg0 = D_80041F08 | 0x80;
+    }
+    return arg0;
+}
 #pragma GLOBAL_ASM("asm/nonmatchings/init_B1B0/func_1000C530.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/init_B1B0/func_1000C7E8.s")
+// NON-MATCHING (score 1865): logic + top control flow (out-of-line return
+// trampolines) verified byte-identical. Remaining diffs are one FP register-
+// allocation decision cascading through the whole float block: the target keeps
+// arg2 in $f14 (mtc1 a2,f14 at entry) so D_8002C238 gets the persistent $f18 and
+// 100.0f is re-materialized twice; IDO instead spills arg2 to 0x20(sp) here,
+// freeing $f14 for D_8002C238 and pinning 100.0f in $f18. Pure register-alloc
+// near-miss (PERMUTER CANDIDATE).
+// s32 func_1000C7E8(s32 arg0, s32 arg1, f32 arg2, s32 arg3, f32 arg4) {
+//     s32 v0;
+//     f32 v;
+//     if (D_800BE9F0 == 0x31) {
+//         if (arg0 != 2) {
+//             if (func_1000B1B0(9) == 0) {
+//                 func_1000E704(0x3E, 0, 0xFFFF);
+//                 func_1000E40C(0x3E, 0x7FFF);
+//                 func_1000D96C(0x3D, 0x3E, 4);
+//             }
+//             return 2;
+//         }
+//         return 0;
+//     }
+//     v0 = D_8002B070;
+//     if (v0 == 0) { v0 = 1; D_8002B070 = v0; }
+//     if (arg0 != v0) { arg0 = v0; }
+//     v = D_8002C238 - sqrtf((arg2 - -4000.0f) * (arg2 - -4000.0f) + arg4 * arg4) * 10.0f;
+//     if (v < 100.0f) { v = 100.0f; } else if (D_8002C238 < v) { v = D_8002C238; }
+//     func_1000E40C(0x3E, (s32) v);
+//     return arg0;
+// }
 
 #pragma GLOBAL_ASM("asm/nonmatchings/init_B1B0/func_1000C934.s")
-// NON-MATCHING: close but last part isn't quite right
+// NON-MATCHING (score 145): byte-identical except sp3C is allocated to v1
+// instead of a1, producing one extra `move a1,v1` before the func_1000E40C
+// call. Pure register-coloring near-miss (PERMUTER CANDIDATE). The target loads
+// sp3C directly into a1 at every reload (17d4/1824) so it is already the arg1 of
+// func_1000E40C(0x54, sp3C); no C form observed forces IDO to color it a1 (clean
+// form scores 825 with t-regs+move; the temp_a1 idiom below reaches v1 @145).
 // s32 func_1000C934(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
 //     s32 sp3C;
 //     s32 sp38;
@@ -258,7 +364,32 @@ s32 func_1000CA18(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
     return tmp | 0x80000000;
 }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/init_B1B0/func_1000CAE4.s")
+s32 func_1000CAE4(s32 arg0, u8 arg1, f32 arg2, f32 arg3, f32 arg4) {
+    s32 tmp;
+
+    tmp = arg0 & 2;
+    arg0 = arg0 & 1;
+
+    if (D_800BE9F0 == 0x42) {
+        func_10011FA0((s32 *) 4);
+        if (arg0 == 0) {
+            arg0 = 1;
+            func_1000E704(0x58, 1, 0xFFFF);
+        }
+    } else {
+        if (arg0 != 0) {
+            func_1000E704(0x58, 0, 0xFFFF);
+            func_1000E40C(0x58, 16000);
+            arg0 = 0;
+        }
+    }
+
+    if (tmp == 0) {
+        func_10008790(arg1, 0x1000, 0, 1);
+        tmp = 2;
+    }
+    return tmp | arg0;
+}
 
 void func_1000CBA8(s32 arg0) {
     if (D_800417B0[0] != NULL) {
@@ -271,27 +402,21 @@ void func_1000CBA8(s32 arg0) {
     }
 }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/init_B1B0/func_1000CBF0.s")
-// NON-MATCHING: JUSTREG? need some love
-// void func_1000CBF0(s32 *arg0, s32 *arg1, s32 arg2) {
-//     struct151 *tmp;
-//     s32 i;
-//     s32 tmp2;
-//
-//     for (i = 0; i < 3; i++) {
-//         if (arg2 & (1 << i)) {
-//             tmp = &D_800417B0[i];
-//             tmp2 = tmp->unk0;
-//             if (tmp2) {
-//                 tmp->unk5A = arg0;
-//                 tmp->unk5C = *arg1;
-//                 if (arg1 == 0) {
-//                   tmp->unk58 = *arg0;
-//                 }
-//             }
-//         }
-//     }
-// }
+void func_1000CBF0(s32 arg0, s32 arg1, s32 arg2) {
+    s32 i;
+
+    for (i = 0; i < 3; i++) {
+        if (((1 << i) & arg2) != 0) {
+            if (D_800417B0[i] != NULL) {
+                D_800417B0[i]->unk5A = arg0;
+                D_800417B0[i]->unk5C = arg1;
+                if (arg1 == 0) {
+                    D_800417B0[i]->unk58 = arg0;
+                }
+            }
+        }
+    }
+}
 
 // #pragma GLOBAL_ASM("asm/nonmatchings/init_B1B0/func_1000CC54.s")
 void func_1000CC54(s32 arg0) {
@@ -334,13 +459,104 @@ s32 func_1000CD40(s32 arg0, s32 arg1, s32 arg2) {
 }
 
 #pragma GLOBAL_ASM("asm/nonmatchings/init_B1B0/func_1000CDA0.s")
+// NON-MATCHING (score 1670): logic is correct, but the early `return 1` guards
+// compile to branch-likely + inline returns where the target uses plain beqz/bltz
+// branches to shared epilogue trampolines placed at the function end. IDO
+// return-placement heuristic not reproduced from structured C (confirmed: guards
+// 2 & 3 want plain beqz/bltz+nop to out-of-line returns; IDO emits inverted bnezl
+// with the continue-path load hoisted into the delay slot). PERMUTER CANDIDATE.
+// s32 func_1000CDA0(u8 arg0, struct137 *arg1) {
+//     if (arg0 == 0) return 1;
+//     if (arg1 == NULL) return 1;
+//     if (arg1->unk0 < 0) return 1;
+//     if (D_800417B0[arg1->unk0] == NULL) return 1;
+//     if (arg1->unk4 <= 0) return 1;
+//     if (func_1000853C(arg1->unk0) == 3) return 1;
+//     if ((D_8002B078[arg1->unk4][0] & 0x20) == 0) {
+//         D_800418AC[arg1->unk0] |= 3;
+//     }
+//     return (u8)(arg0 & ~D_800418AC[arg1->unk0]) == 0;
+// }
 #pragma GLOBAL_ASM("asm/nonmatchings/init_B1B0/func_1000CEAC.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/init_B1B0/func_1000D2F8.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/init_B1B0/func_1000D758.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/init_B1B0/func_1000D96C.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/init_B1B0/func_1000DE1C.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/init_B1B0/func_1000DEC4.s")
+
+void func_1000DE1C(s32 arg0, s32 arg1) {
+    s32 count;
+    s32 i;
+    s32 sp34[3];
+
+    arg0 &= 0xFFF;
+    if (arg0 == 0) {
+        func_1000DEC4();
+        count = func_1000B548(sp34);
+        for (i = 0; i < count; i++) {
+            if (sp34[i] > 0) {
+                func_1000D96C(0, sp34[i], arg1);
+            }
+        }
+    } else {
+        func_1000D96C(0, arg0, arg1);
+    }
+}
+
+void func_1000DEC4(void) {
+    struct137 *p;
+
+    // NOTE: keep the init on the same source line as the `do` - at -g3 IDO groups
+    // the three hoisted %hi/%lo address pairs per line, and splitting them changes
+    // the order the addiu halves are emitted in.
+    p = D_800419A8; do {
+        if (p->unk0 == -1) {
+            if (p->unk4 != -1) {
+                p->unk4 = -1;
+            }
+        } else if (func_1000853C(p->unk0) == 0) {
+            D_800417B0[p->unk0] = NULL;
+            p->unk0 = -1;
+            p->unk4 = -1;
+        }
+        // structs.h types offset 0x60 of struct137 as u16 pad60; the game stores a word there
+        *(s32 *) &p->pad60 = 0;
+        p++;
+    } while (p != (struct137 *) D_80041E58);
+}
 #pragma GLOBAL_ASM("asm/nonmatchings/init_B1B0/func_1000DF68.s")
+// NON-MATCHING (best score 415): structure verified correct. Remaining diffs are
+// (a) the final clamp's `v < 0x8000` test emits beqzl instead of the target's
+// bnezl-with-store-in-delay (branch-likely polarity that no observed C form flips
+// here; factored/inverted/nested variants all score 575-618, worse), and (b) the
+// func_1000CC54 pointer access reads v1 where the target reads v0 (the pointer is
+// live in both after `move v1,v0`; a pure coloring choice). PERMUTER CANDIDATE.
+// s16 func_1000DF68(s32 arg0, s32 arg1, s32 arg2) {
+//     struct151 *v1 = func_1000B1FC(arg0);
+//     s32 v;
+//     if (v1 != NULL) {
+//         v1->unk4E = arg1;
+//         if (arg2 == 1) {
+//             v1->unk4C = arg1;
+//             if (v1->unk0 >= 0) {
+//                 func_1000CC54(v1->unk0);
+//             }
+//         }
+//         if (arg2 >= 2) {
+//             v = v1->unk4C - arg1;
+//             if (v < 0) { v = -v; }
+//             v = v / arg2;
+//             if (v <= 0) {
+//                 v = 2;
+//             } else {
+//                 if (v < 0x8000) { v1->unk50 = v; goto done; }
+//                 v = 0x7FFF;
+//             }
+//             v1->unk50 = v;
+//         done:;
+//         } else {
+//             v1->unk50 = 0x200;
+//         }
+//     }
+// }
 
 void func_1000E054(s32 arg0, s32 arg1) {
     struct151 *sp1C;
@@ -389,7 +605,76 @@ s32 func_1000E134(s32 arg0) {
 }
 
 #pragma GLOBAL_ASM("asm/nonmatchings/init_B1B0/func_1000E17C.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/init_B1B0/func_1000E2F4.s")
+// NON-MATCHING (score 1625): logic verified correct (3 loops over D_800419A8).
+// IDO CSE's &D_800419A8 across the three loops into one register (with `move`s)
+// while the target re-materializes lui/addiu each loop; also s3/s4/s5 constant
+// renames. GCSE/register-pressure mismatch, not expressible from C.
+// void func_1000E17C(void) {
+//     struct137 *p;
+//     s32 cls;
+//     struct137 *tmp;
+//     p = D_800419A8;
+//     do {
+//         if (p->unk4 > 0) {
+//             cls = ((s32 *) &D_8002B074[p->unk4])[1] & ~0xF0;
+//             if ((cls == 1) || (cls == 3)) {
+//                 if (p->unk0 == -1) { p->unk4 = -1; }
+//             }
+//         }
+//         p++;
+//     } while (p < (struct137 *) D_80041E58);
+//     p = D_800419A8;
+//     do {
+//         if (p->unk4 > 0) {
+//             tmp = *(struct137 **) &p->pad60;
+//             if ((tmp != NULL) && (tmp->unk4 == -1)) { *(s32 *) &p->pad60 = 0; }
+//             if ((p->unk10 != NULL) && (p->unk10->unk4 == -1)) { p->unk10 = NULL; }
+//         }
+//         p++;
+//     } while (p < (struct137 *) D_80041E58);
+//     p = D_800419A8;
+//     do {
+//         if (p->unk4 > 0) {
+//             cls = ((s32 *) &D_8002B074[p->unk4])[1] & ~0xF0;
+//             if ((cls == 1) || (cls == 3)) {
+//                 if (p->unk0 != -1) { func_1000DE1C(p->unk4, 4); }
+//             }
+//         }
+//         p++;
+//     } while (p != (struct137 *) D_80041E58);
+// }
+void func_1000E2F4(s32 arg0) {
+    struct151 *p;
+    s32 i;
+
+    for (i = 0; i < 3; i++) {
+        p = D_800417B0[i];
+        if (p == NULL) {
+            continue;
+        }
+        if (p->unk4 <= 0) {
+            continue;
+        }
+        if (p->unk15 != 0) {
+            continue;
+        }
+        if (arg0 != 0) {
+            func_10008EE0((u8)i, 0);
+            if ((((s32 *) &D_8002B074[D_800417B0[i]->unk4])[1] & 0x10) != 0) {
+                continue;
+            }
+            func_10008F58((u8)i);
+        } else {
+            if ((((s32 *) &D_8002B074[p->unk4])[1] & 0x10) == 0) {
+                func_100084D8((u8)i);
+                p = D_800417B0[i];
+            }
+            p->unk30 = -1;
+            func_1000CC54(i);
+        }
+    }
+    D_80041F00 = (u8) arg0;
+}
 
 void func_1000E40C(s32 arg0, s32 arg1) {
     struct151 *temp_v0;
@@ -408,8 +693,67 @@ void func_1000E40C(s32 arg0, s32 arg1) {
     }
 }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/init_B1B0/func_1000E46C.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/init_B1B0/func_1000E588.s")
+s32 func_1000E46C(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
+    struct151 *v0 = func_1000B1FC(arg0);
+    s32 v1;
+
+    arg1 = arg1 * 255 / 100;
+    if (arg1 >= 0x100) {
+        arg1 = 0xFF;
+    } else if (arg1 < 0) {
+        arg1 = 0;
+    }
+    if (v0 != NULL) {
+        if (v0->unk0 >= 0) {
+            if (arg3 < 0) {
+                func_1000886C(v0->unk0, arg2, arg1);
+            } else {
+                func_10008790(v0->unk0, arg2, arg1, arg3);
+            }
+            return 1;
+        }
+        if (arg1 == 0) {
+            v0->unk38 |= arg2;
+        } else if (arg1 > 0) {
+            v0->unk38 &= ~arg2;
+        }
+        v1 = 0;
+        if (arg2 != 0) {
+            do {
+                if (arg2 & 1) {
+                    v0->unk3C[v1] = arg1;
+                }
+                v1++;
+                arg2 = arg2 >> 1;
+            } while (arg2 != 0);
+        }
+        return 1;
+    }
+    return 0;
+}
+s32 func_1000E588(s32 arg0, s32 arg1, s32 arg2) {
+    struct151 *v1 = func_1000B1FC(arg0);
+    if (v1 != NULL) {
+        if (v1->unk0 >= 0) {
+            if (arg1 >= 101) {
+                arg1 = 100;
+            } else if (arg1 < 0) {
+                arg1 = 0;
+            }
+            func_1000886C(v1->unk0, arg2, arg1 * 255 / 100);
+            return 1;
+        } else {
+            if (arg1 <= 0) {
+                v1->unk38 |= arg2;
+                return 1;
+            } else if (arg1 > 0) {
+                v1->unk38 &= ~arg2;
+                return 1;
+            }
+        }
+    }
+    return 0;
+}
 
 s32 func_1000E654(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
     struct151 *sp1C;
@@ -462,21 +806,26 @@ s32 func_1000E770(s32 *arg0, s32 *arg1) {
 }
 
 #pragma GLOBAL_ASM("asm/nonmatchings/init_B1B0/func_1000E7A0.s")
-// NON-MATCHING: mostly just wrong registers
+// NON-MATCHING (score 760): logic verified correct. Remaining diffs are pure
+// register allocation (target keeps arg0 in a0 and uses v0 for the F0C/F08
+// addresses; mine reuses a0) plus one branch-likely hoist of the `& 0x10`
+// check into the `& 8` guard delay slot. Permuter candidate.
 // void func_1000E7A0(u32 arg0, s32 arg1) {
+//     s32 tmp;
 //     if ((arg0 & 1) == 1) {
 //         D_80041F04 |= 1;
 //     } else if (arg0 & 2) {
 //         D_80041F08 += arg1;
 //         D_80041F0C += 1;
 //     } else if (arg0 & 4) {
-//         D_80041F08 = 1 + arg1;
+//         D_80041F08 = arg1 + 1;
 //         D_80041F04 |= 4;
 //     } else if (arg0 & 8) {
-//         D_80041F0C = (arg1 >> 8) & 0xff;
-//         if ((D_80041F0C == 0) || (D_80041F0C == 4) || (D_80041F0C == 5))  {
+//         D_80041F0C = arg1 >> 8;
+//         tmp = arg1 & 0xFF;
+//         if ((tmp == 0) || (tmp == 4) || (tmp == 5)) {
 //             D_80041F08 = 2;
-//         } else if (D_80041F0C == 10) {
+//         } else if (tmp == 10) {
 //             D_80041F08 = 1;
 //         } else {
 //             D_80041F08 = 3;

--- a/conker/src/init_EB00.c
+++ b/conker/src/init_EB00.c
@@ -63,35 +63,54 @@ s32 func_1000EC24(struct251 *arg0, s32 arg1, s32 *arg2, struct11 *arg3, struct04
 }
 
 #pragma GLOBAL_ASM("asm/nonmatchings/init_EB00/func_1000ECCC.s")
-// ? func_1000ECCC(void *arg0, ? arg1, ? arg2, ? arg3, void *arg6) {
-//     s16 temp_a1;
-//     s32 temp_t4;
-//     s32 temp_v1;
-//     u16 temp_v0;
-//
-//     temp_v1 = arg0->unk18;
-//     temp_v0 = *arg6;
+// NON-MATCHING: best 93 (permuter reached 55). Logic byte-correct; remaining diff
+// is arg6 pointer landing in a3 (mine) vs a2 (target) -> arg-home store order. Permuter running.
+// typedef struct { s16 unk0; u8 pad2[6]; u16 unk8; s16 unkA; s32 unkC; u8 p10[8]; s32 unk18; s32 unk1C; } ECCCStruct;
+// s32 func_1000ECCC(ECCCStruct *arg0, s32 arg1, s32 *arg2, struct11 *arg3, struct04 *arg4, s32 *arg5, u16 *arg6) {
+//     s16 temp_a1; s32 temp_v1; u16 temp_v0;
+//     temp_v1 = arg0->unk18; temp_v0 = *arg6; temp_a1 = temp_v1;
 //     if (temp_v0 != 0) {
-//         arg0->unk18 = (s32) ((temp_v0 << 0x10) | (temp_v1 & 0xFFFF));
-//         arg0->unk0 = (u16)0;
-//         *arg6 = (u16)0U;
-//     }
-//     temp_a1 = (s16) temp_v1 - *(void *)0x800BE9E4;
-//     if ((s32) temp_a1 <= 0) {
-//         temp_t4 = arg0->unk18 >> 0x10;
-//         *arg6 = (u16) temp_t4;
-//         arg0->unk0 = (s16) temp_t4;
-//         if (func_10010894(arg0->unk1C, temp_a1, arg6) == 0) {
-//             func_10010344(*arg6, arg0->unk1C, arg0->unkC, arg0->unkA, (?32) arg0->unk8);
-//         }
-//         return 1;
-//     }
-//     arg0->unk18 = (s32) ((arg0->unk18 & 0xFFFF0000) | temp_a1);
-//     return 0;
-// }
+//         arg0->unk18 = (temp_v0 << 0x10) | (temp_v1 & 0xFFFF);
+//         arg0->unk0 = 0; *arg6 = 0; temp_v1 = arg0->unk18; }
+//     temp_a1 -= D_800BE9E4;
+//     if (temp_a1 <= 0) {
+//         *arg6 = temp_v1 >> 0x10; arg0->unk0 = temp_v1 >> 0x10;
+//         if (func_10010894((struct127 *) arg0->unk1C) == 0) {
+//             func_10010344(*arg6, arg0->unk1C, arg0->unkC, arg0->unkA, arg0->unk8); }
+//         return 1; }
+//     arg0->unk18 = (temp_v1 & 0xFFFF0000) | temp_a1;
+//     return 0; }
 
 #pragma GLOBAL_ASM("asm/nonmatchings/init_EB00/func_1000EDA0.s")
+// BLOCKED BY HEADER: reconstruction is byte-shaped (sibling of matched func_1000EC24),
+// but real signature is `s32 func_1000EDA0(struct* a0, s32,s32,s32,s32,s32, u16* arg6)`
+// (7 params, arg6 at 0x40, s32 return). functions.h:956 wrongly declares it
+// `void func_1000EDA0(void*,s32,s32,s32,void*)` (5 params/void) -> IDO redeclaration
+// error. Needs header fix to match. Reconstruction:
+// s32 func_1000EDA0(EDA0Struct *arg0, s32,s32,s32,s32,s32, u16 *arg6) {
+//     s16 temp_a1; s32 temp_v1; u16 temp_v0;
+//     temp_v1 = arg0->unk18; temp_v0 = *arg6; temp_a1 = temp_v1;
+//     if (temp_v0 != 0) { arg0->unk18 = (temp_v0<<0x10)|(temp_v1&0xFFFF);
+//         arg0->unk0 = 0; *arg6 = 0; temp_v1 = arg0->unk18; }
+//     temp_a1 -= D_800BE9E4;
+//     if (temp_a1 <= 0) { *arg6 = temp_v1>>0x10; arg0->unk0 = temp_v1>>0x10;
+//         func_10010630(*arg6, arg0->unk1C, arg0->unkC, arg0->unkA, arg0->unk8); return 1; }
+//     arg0->unk18 = (temp_v1 & 0xFFFF0000) | temp_a1; return 0; }
+
 #pragma GLOBAL_ASM("asm/nonmatchings/init_EB00/func_1000EE70.s")
+// NON-MATCHING: best 1650 but all ops match; only diff is the first two guards
+// use branch-likely beqzl (li v0,1 in delay) vs my plain beqz+hoisted li.
+// Permuter running. arg0 = { s16 unk2@2,unk4@4,unk6@6; struct127* unk18@18; s32 unk1C@1C; u16 unk24@24 }
+// s32 func_1000EE70(void *arg0, s32, void *arg2, s32, s32, void *arg5) {
+//     EE70Struct *p = arg0; struct127 *v1 = p->unk18;
+//     if (v1 == NULL) return 1;
+//     if (*(s32 *)arg2 == 0) return 1;
+//     if ((v1->interaction_state != 0) && (v1->unique_id == (p->unk1C & 0xFF))) {
+//         *(s32 *)arg5 = (((u32) v1->unk184 >> 3) & 0x30) << 1;
+//         p->unk2 = v1->x_position; p->unk4 = v1->y_position; p->unk6 = v1->z_position;
+//         return 0; }
+//     if (func_1000F44C(p->unk24) != 0) return 1;
+//     return 0; }
 
 s32 func_1000EF40(struct57 *arg0, struct57 *arg1, s32 *arg2, s32 arg3, s32 arg4, s32 arg5, u16 *arg6) {
     if (arg0->unk10 & 0x80) {
@@ -108,7 +127,20 @@ s32 func_1000EF40(struct57 *arg0, struct57 *arg1, s32 *arg2, s32 arg3, s32 arg4,
 }
 
 #pragma GLOBAL_ASM("asm/nonmatchings/init_EB00/func_1000EFB4.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/init_EB00/func_1000F1A8.s")
+void func_1000F1A8(void) {
+    s32 i;
+
+    D_80042760 = 0;
+    D_80041FD9 = 1;
+    D_80041FD8 = 0;
+    bzero(D_800425E0, 0x180);
+    for (i = 0; i < 16; i++) {
+        D_800425E0[i].unk2 = i + 16;
+    }
+    D_80041F50 = 0;
+    func_100176EC();
+    D_80041F60 = D_80041F61 = 0;
+}
 
 void func_10017780(u8 arg0, u16 arg1);
 s32* allocate_memory(s32, s32, s32, s32);
@@ -187,42 +219,56 @@ s32 func_1000F44C(u16 arg0) {
     return 0;
 }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/init_EB00/func_1000F4D8.s")
+extern struct120 D_800426A0[];
+s32 func_1000F4D8(u16 arg0) {
+    struct120 *p;
+
+    arg0 &= 0x7FFF;
+    p = D_800425E0; do {
+        if (p->unk8 != 0) {
+            if ((p->unk4 & 0x7FFF) == arg0) {
+                if (func_100173C4(&p->unk8) != 0) {
+                    return 1;
+                }
+            }
+        }
+        p++;
+    } while (p != D_800426A0);
+    return 0;
+}
+
 #pragma GLOBAL_ASM("asm/nonmatchings/init_EB00/func_1000F568.s")
+// NON-MATCHING (best 2100): PERMUTER CANDIDATE. Algorithm byte-correct and structure
+// byte-ALIGNED (every instruction present and in order); the entire remaining score is a
+// systematic register-coloring permutation (mine {val=a0,bit=a1,arg1=a2,arg0=t2} vs target
+// {val=v0,bit=v1,arg1=a1,arg0=t1}) that cannot be forced from C. Divisor=arg1 gives divu on
+// the first (unsigned) modulo but signed div in the loop, matching the target's break-guards.
+// s32 func_1000F568(s32 arg0, s32 arg1) {
+//     s32 bit; u8 *p; s32 val; s32 mask; s32 n; s32 newval; s32 b;
+//     bit = func_150ADA20() % (u32) arg1;
+//     if (arg0 >= 0x6E2) { return 1; }
+//     if (arg1 < 2) { return arg0; }
+//     p = (u8 *) D_80041F5C + arg0;
+//     if (D_80041F5C != NULL) {
+//         if (arg1 < 8) {
+//             b = *p; val = b;
+//             if (!((b & 0x80) && (b & (mask = (1 << arg1) - 1)))) { val = 0xFF; mask = (1 << arg1) - 1; }
+//             if ((val & (1 << bit)) == 0) {
+//                 n = bit + 1;
+//                 do { bit = n % arg1; n = bit + 1; } while ((val & (1 << bit)) == 0); }
+//             newval = val ^ (1 << bit); *p = newval;
+//             if (((newval & 0xFF) & mask) == 0) { ((u8 *) D_80041F5C)[arg0] = val ^ mask; }
+//         } else { *p = bit + 1; }
+//     }
+//     return arg0 + bit; }
+
 #pragma GLOBAL_ASM("asm/nonmatchings/init_EB00/func_1000F6B8.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/init_EB00/func_1000F85C.s")
-// NON-MATCHING: not even close
-// void func_1000F85C(s32 arg0, s16 arg1, s32 arg2) {
-//     f32 sp1C;
-//     s32 sp18;
-//     s16 temp_a1;
-//     s16 temp_a1_2;
-//     s32 temp_t6;
-//     s16 phi_a1;
-//
-//     temp_t6 = arg0 & 0xFFFF;
-//     temp_a1 = arg1;
-//     if (temp_t6 >= 16) {
-//         sp18 = temp_t6;
-//         arg1 = temp_a1;
-//         temp_a1_2 = arg1;
-//         if (func_1000F3D0(temp_t6) != 0) {
-//             if (temp_a1_2 == 16) {
-//                 sp18 = sp18;
-//                 arg1 = temp_a1_2;
-//                 sp1C = alCents2Ratio(arg2, temp_a1_2);
-//                 arg2 = (s32) sp1C;
-//                 phi_a1 = arg1;
-//             } else {
-//                 phi_a1 = temp_a1_2;
-//                 if (temp_a1_2 == 0x11) {
-//                     phi_a1 = (u16)0x10;
-//                 }
-//             }
-//             func_10017714((((sp18 & 0xF) * 0xC) + 0x80040000) - 0x25E8, phi_a1, arg2);
-//         }
-//     }
-// }
+// NON-MATCHING: even with the header fixed to (u16,s16,s32) this reaches only score 10
+// (a register diff), not 0 — header fix alone insufficient. Left as pragma. Reconstruction:
+// void func_1000F85C(u16 arg0, s16 arg1, s32 arg2){ if(arg0>=0x10 && func_1000F3D0(arg0)){
+//   if(arg1==0x10){f32 f=alCents2Ratio(arg2);arg2=*(s32*)&f;} else if(arg1==0x11)arg1=0x10;
+//   func_10017714((s32)D_800425E0[arg0&0xF].unk8,arg1,arg2);} }
 
 void func_1000F91C(u16 arg0, u16 arg1, s16 arg2, u8 arg3, s32 arg4,
                    s16 arg5, s16 arg6, s16 arg7, s16 arg8, s16 arg9) {
@@ -245,67 +291,149 @@ void func_1000F9D4(u16 arg0, s16 arg1, s16 arg2, s16 arg3) {
 
 #pragma GLOBAL_ASM("asm/nonmatchings/init_EB00/func_1000FA64.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/init_EB00/func_1000FC18.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/init_EB00/func_1000FD38.s")
+// NON-MATCHING (best 260): loop body byte-perfect. Same base-vs-blez scheduling
+// as func_1000FDF4 (target schedules move s1/s2 before blez, base after; mine
+// base before) + downstream first-compare operand order (both resist permuter).
+// typedef struct { u16 unk0; s16 unk2; s16 unk4; s16 unk6; u16 unk8; u8 p[6]; s32 unk10; u8 p2[0x10]; u16 unk24; u8 p3[0xA]; } FC18Elem;
+// void func_1000FC18(u16 arg0, s16 arg1, s16 arg2, s16 arg3, u16 arg4) {
+//     FC18Elem *p; s32 *new_var; s32 count; s32 i;
+//     count = D_80042760; p = (FC18Elem *) D_80041FE0;
+//     for (i = 0; i < count; i++, p++) {
+//         if ((arg0 == p->unk0) && (arg1 == p->unk2) && (arg2 == p->unk4) &&
+//             (arg3 == p->unk6) && (arg4 == (p->unk8 & 0x7FFF))) {
+//             new_var = &D_80042760;
+//             if (p->unk24 != 0) { func_100111C8(p->unk24); count = *new_var; }
+//             p->unk10 |= 0x80; } } }
+void func_1000FD38(s32 arg0, s32 arg1, s32 arg2) {
+    struct15 *p;
+    s32 *new_var;
+    s32 count;
+    s32 i;
+
+    count = D_80042760;
+    p = D_80041FE0;
+    for (i = 0; i < count; i++, p++) {
+        if ((arg0 == p->unk14) && (arg1 == p->unk18) && (arg2 == p->unk1C)) {
+            new_var = &D_80042760;
+            if (p->unk24 != 0) {
+                func_100111C8(p->unk24);
+                count = *new_var;
+            }
+            p->unk10 |= 0x80;
+        }
+    }
+}
 #pragma GLOBAL_ASM("asm/nonmatchings/init_EB00/func_1000FDF4.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/init_EB00/func_1000FE88.s")
-// ? func_1000FE88(s32 arg0, s32 arg1, void *arg2) {
-//     void *sp1C;
-//     s32 temp_t7;
-//     u16 temp_a0;
-//     void *temp_v1;
-//     ? phi_return;
-//
-//     phi_return = 1;
-//     if (arg1 < *arg2) {
-//         temp_t7 = arg1 * 0x30;
-//         temp_v1 = arg0 + temp_t7;
-//         temp_a0 = temp_v1->unk24;
-//         if (temp_a0 != 0) {
-//             sp1C = temp_v1;
-//             func_100111C8(temp_a0, arg0);
-//         }
-//         (arg0 + temp_t7)->unk10 = (s32) ((arg0 + temp_t7)->unk10 | 0x80);
-//         phi_return = 0;
-//     }
-//     return phi_return;
-// }
+// NON-MATCHING: best 280. Loop body byte-perfect; remaining diff is count in
+// v0(target)/v1(mine) and base-setup vs moves scheduled around the blez guard.
+// Permuter running. void func_1000FDF4(u16 arg0) {
+//     struct15 *p; s32 *new_var; s32 count; s32 i; u16 temp;
+//     count = D_80042760; p = D_80041FE0;
+//     for (i = 0; i < count; i++, p++) {
+//         temp = p->unk24;
+//         if (temp == arg0) {
+//             new_var = &D_80042760;
+//             if (temp != 0) { func_100111C8(temp); count = *new_var; }
+//             p->unk10 |= 0x80; } } }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/init_EB00/func_1000FEF0.s")
-// NON-MATCHING: needs a re-work
-// s32 func_1000FEF0(u16 arg0, struct127 *arg1, s32 arg2) {
-//     s32 i;
-//     struct15 *tmp;
-//
-//     if (arg0 == 0) {
-//         // nothing
-//     } else {
-//         for (i = 0; i < D_80042760; i++) {
-//             tmp = &D_80041FE0[i];
-//             if ((arg0 == tmp->unk24) &&
-//                 (arg1 == tmp->unk18) &&
-//                 (arg2 == tmp->unk1C) &&
-//                 ((tmp->unk10 & 0x80) == 0)) {
-//                 return i;
-//             }
-//         }
-//     }
-//     return -1;
-// }
+s32 func_1000FE88(struct15 *arg0, s32 arg1, s32 *arg2) {
+    if (arg1 < *arg2) {
+        if (arg0[arg1].unk24 != 0) {
+            func_100111C8(arg0[arg1].unk24);
+        }
+        arg0[arg1].unk10 |= 0x80;
+        return 0;
+    }
+    return 1;
+}
 
-#pragma GLOBAL_ASM("asm/nonmatchings/init_EB00/func_1000FF90.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/init_EB00/func_1001001C.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/init_EB00/func_100100E0.s")
+s32 func_1000FEF0(u16 arg0, void *arg1, s32 arg2) {
+    u16 id;
+    s32 i;
+
+    if (!arg0) {
+        return -1;
+    }
+    for (i = 0; i < D_80042760; i++) {
+        if ((arg0 == (*(&D_80041FE0[i])).unk24) && ((s32) arg1 == D_80041FE0[i].unk18) &&
+            (arg2 == D_80041FE0[i].unk1C) && ((D_80041FE0[i].unk10 & 0x80) == 0)) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+s32 func_1000FF90(s32 arg0, s32 arg1, s32 arg2) {
+    s32 i;
+
+    for (i = 0; i < D_80042760; i++) {
+        if ((arg0 == D_80041FE0[i].unk14) &&
+            ((arg1 == D_80041FE0[i].unk18) || (arg1 == -1)) &&
+            ((arg2 == D_80041FE0[i].unk1C) || ((u32) arg2 == 0xFFFFFFFFU)) &&
+            ((D_80041FE0[i].unk10 & 0x80) == 0)) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+void func_1001001C(s32 arg0, s32 arg1, s32 arg2, s32 arg3, s32 arg4) {
+    struct15 *p;
+    s32 *new_var;
+    s32 count;
+    s32 i;
+
+    count = D_80042760;
+    p = D_80041FE0;
+    for (i = 0; i < count; i++, p++) {
+        if ((arg0 == p->unk14) && (arg1 == p->unk18) && (arg2 == p->unk1C)) {
+            new_var = &D_80042760;
+            *(f32 *)&p->unk2C = alCents2Ratio(arg4);
+            p->unkC = arg3;
+            count = *new_var;
+        }
+    }
+}
+
+void func_100100E0(s32 arg0, s32 arg1, s32 arg2, s32 arg3, s32 arg4, s32 arg5) {
+    s32 count;
+    struct15 *p;
+
+    p = D_80041FE0;
+    count = D_80042760;
+    if (count > 0) {
+        p = D_80041FE0;
+        do {
+            if ((arg0 == p->unk14) && (arg1 == p->unk18) && (arg2 == p->unk1C)) {
+                p->unk14 = arg3;
+                p->unk18 = arg4;
+                p->unk1C = arg5;
+            }
+            p++;
+        } while (p < &D_80041FE0[count]);
+    }
+}
+
 #pragma GLOBAL_ASM("asm/nonmatchings/init_EB00/func_10010154.s")
 #pragma GLOBAL_ASM("asm/nonmatchings/init_EB00/func_10010344.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/init_EB00/func_10010558.s")
+s32 func_1000ECCC();
+void func_10010558(u16 arg0, struct127 *arg1, s32 arg2, s16 arg3, u16 arg4, s32 arg5) {
+    if (arg5 <= 0) {
+        func_10010344(arg0, arg1, arg2, arg3, arg4);
+    } else {
+        func_1000FA64(arg0, arg1->x_position, arg1->y_position, arg1->z_position, arg2, arg4, arg3, func_1000ECCC, arg5, arg1, 0, 0);
+    }
+}
 
 #pragma GLOBAL_ASM("asm/nonmatchings/init_EB00/func_10010630.s")
+// NON-MATCHING: best 2084 (ops all match; target keeps arg2 in saved reg s1,
+// mine spills to stack -> regalloc cascade). Permuter running.
 // void func_10010630(u16 arg0, struct127 *arg1, s32 arg2, s16 arg3, u16 arg4) {
 //     if (arg1->interaction_state != 0) {
 //         if (arg1->camera != 0) {
-//             func_10010F30(arg0, arg2 & 0xFFFF, 64, 0, (((u32) arg1->unk184 >> 3) & 0x30) * 2); //
+//             func_10010F30(arg0, arg2 & 0xFFFF, 64, 0, (((u32) arg1->unk184 >> 3) & 0x30) * 2);
 //         } else {
-//             func_1000FA64(arg0, arg1->x_position, arg1->y_position, arg1->z_position, arg2, arg4, arg3, (void *)func_1000EE70, arg1, arg1->unique_id, 0, 0);
+//             func_1000FA64(arg0, arg1->x_position, arg1->y_position, arg1->z_position, arg2, arg4, arg3, (void *) func_1000EE70, arg1, arg1->unique_id, 0, 0);
 //         }
 //     }
 // }
@@ -354,26 +482,24 @@ s32 func_10010894(struct127 *arg0) {
     return 0;
 }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/init_EB00/func_1001091C.s")
-// NON-MATCHING: something isnt right...
-// void func_1001091C(struct127 *arg0, struct15 *arg1) {
-//     s32 temp_v0;
-//
-//     if ((arg1 != NULL) && (arg0->unk0 != 0)) {
-//         if (arg0->camera != 0) {
-//             if (arg0->unk8E != 0) {
-//                 func_1000F85C(arg0->unk8E, 8, arg1->unk1C); // help
-//             }
-//         } else {
-//             temp_v0 = func_1000FF90(func_1000EE70, arg0, arg0->unique_id | 0x10000);
-//             if (temp_v0 != -1) {
-//                 D_80041FEC[temp_v0][0] = arg1;
-//             } else {
-//                 arg0->unk8E = 0;
-//             }
-//         }
-//     }
-// }
+void func_1001091C(struct127 *arg0, struct15 *arg1) {
+    s32 temp_v0;
+
+    if ((arg1 != NULL) && (arg0->interaction_state != 0)) {
+        if (arg0->camera != 0) {
+            if (arg0->unk8E != 0) {
+                func_1000F85C(arg0->unk8E, 8, *(s32 *)&arg1);
+            }
+        } else {
+            temp_v0 = func_1000FF90(func_1000EE70, arg0, arg0->unique_id | 0x10000);
+            if (temp_v0 != -1) {
+                D_80041FEC[temp_v0][0] = (s32) arg1;
+            } else {
+                arg0->unk8E = 0;
+            }
+        }
+    }
+}
 
 void func_100109D0(struct127 *arg0) {
     if (arg0->camera) {
@@ -431,13 +557,27 @@ void func_10010AA8(struct127 *arg0) {
 }
 
 #pragma GLOBAL_ASM("asm/nonmatchings/init_EB00/func_10010BE8.s")
-#pragma GLOBAL_ASM("asm/nonmatchings/init_EB00/func_10010E78.s")
+
+s32 func_10010E78(u16 arg0, s32 arg1, u16 arg2, s16 arg3, u8 arg4, s32 arg5, s16 arg6,
+                  s16 arg7, s16 arg8, s16 arg9, s16 argA) {
+    s32 sp2C;
+    s32 tmp = func_1000F6B8(arg5, arg6, arg7, arg8, &sp2C, (s32) arg9, (s32) argA);
+
+    tmp = (u32) (arg2 * tmp) >> 15;
+    if (tmp != 0) {
+        return func_10010BE8(arg0, arg1, tmp, sp2C & 0x7F, arg3, (sp2C & 0x80) | arg4, D_80041FD9);
+    }
+    return 0;
+}
 
 void func_10010F30(s32 arg0, u16 arg1, u8 arg2, s16 arg3, u8 arg4) {
     func_10010BE8(0, arg0, arg1, arg2, arg3, arg4, D_80041FD9);
 }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/init_EB00/func_10010F88.s")
+void func_10010F88(s32 arg0, u16 arg1, s16 arg2, u8 arg3, s32 arg4, s16 arg5, s16 arg6,
+                   s16 arg7, s16 arg8, s16 arg9) {
+    func_10010E78(0, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
+}
 #pragma GLOBAL_ASM("asm/nonmatchings/init_EB00/func_10010FFC.s")
 
 void func_100111C8(u16 arg0) {
@@ -508,24 +648,17 @@ void func_10011E94(s32 arg0) {
 }
 
 #pragma GLOBAL_ASM("asm/nonmatchings/init_EB00/func_10011EB8.s")
-// NON-MATCHING: whats going on here
-// u16 func_10011EB8(s32 arg0, s16 *arg1, s32 arg2, s32 arg3) {
-//     struct120 *temp_v1_2;
-//     s32 temp_v0;
-//     s32 temp_a0;
-//
+// NON-MATCHING (best 220): logic byte-correct with 3 params + 2D reinterp of
+// D_8002C240 (stride 0x14, sub-stride 4; header wrongly says struct120). Remaining
+// diffs are a dead `move a3,a0; move a0,a3` arg0 shuffle at entry (-g3 artifact) and
+// the func_1000F568 branch-delay-slot filler (a0 vs a1). Reconstruction:
+// typedef struct { u16 unk0; u16 unk2; } EB8Sub; typedef struct { EB8Sub sub[5]; } EB8Row;
+// u16 func_10011EB8(s32 arg0, s16 *arg1, s32 arg2) {
+//     EB8Row *base = (EB8Row *) D_8002C240; s32 temp_v0, temp_a0;
 //     temp_v0 = func_1510F8CC(arg0);
 //     if (arg1 != NULL) {
-//         if (D_80082FA0 != 0) {
-//             *arg1 = 0x7FFF / (D_80082FA0 + 1);
-//         } else {
-//             *arg1 = 0x7FFF;
-//         }
-//     }
-//     temp_v1_2 = &D_8002C240[temp_v0 + arg2];
-//     temp_a0 = temp_v1_2->unk0;
-//     if (temp_v1_2->unk2 >= 2) {
-//         temp_a0 = func_1000F568(temp_v0, temp_v1_2->unk2);
-//     }
-//     return temp_a0;
-// }
+//         if (D_80082FA0 != 0) *arg1 = 0x7FFF / (D_80082FA0 + 1); else *arg1 = 0x7FFF; }
+//     temp_a0 = base[temp_v0].sub[arg2].unk0;
+//     if (base[temp_v0].sub[arg2].unk2 >= 2)
+//         temp_a0 = func_1000F568(temp_v0, base[temp_v0].sub[arg2].unk2);
+//     return temp_a0; }


### PR DESCRIPTION
Byte-perfect (asm-differ score 0) decompiled functions across 15 file(s) in the init area, verified against the retail US ROM (sha1 842e3d34...). Non-matching functions remain GLOBAL_ASM pragmas; near-miss reconstructions are kept as comments for future work. Depends on matches/00-build-config (per-file OPT_FLAGS + variables.h extern).